### PR TITLE
Add support for Multiple roles

### DIFF
--- a/src/main/kotlin/screepsai/Harvester.kt
+++ b/src/main/kotlin/screepsai/Harvester.kt
@@ -4,7 +4,7 @@ import screeps.api.*
 
 class Harvester(creep: Creep) : Role(creep) {
     override fun run() {
-        console.log("${creep.name}: State = ${state.name}")
+        debug("State = ${state.name}")
         when (state) {
             CreepState.GET_ENERGY -> {
                 getEnergy()
@@ -24,11 +24,11 @@ class Harvester(creep: Creep) : Role(creep) {
         if (status == ERR_NOT_IN_RANGE) {
             creep.moveTo(energySource.pos.x, energySource.pos.y)
         } else if (status != OK) {
-            console.log("${creep.name}: ERROR Gather failed $status")
+            error("Gather failed with code $status")
         }
 
         if (creep.store.getFreeCapacity() == 0) {
-            console.log("${creep.name}: Energy full")
+            info("Energy full", say = true)
             state = CreepState.DO_WORK
         }
     }
@@ -37,7 +37,7 @@ class Harvester(creep: Creep) : Role(creep) {
         val controller = creep.room.controller
 
         if (controller == null) {
-            console.log("${creep.name}: No controller")
+            error("No controller!", say = true)
             return
         }
 
@@ -46,13 +46,15 @@ class Harvester(creep: Creep) : Role(creep) {
         if (status == ERR_NOT_IN_RANGE) {
             creep.moveTo(controller)
         } else if (status == ERR_NOT_ENOUGH_ENERGY) {
+            info("Out of energy", say = true)
             state = CreepState.GET_ENERGY
             return
         } else if (status != OK) {
-            console.log("${creep.name}: ERROR Upgrade failed: $status")
+            error("Upgrade failed with code $status")
         }
 
         if (creep.store.getCapacity(RESOURCE_ENERGY) <= 0) {
+            info("Out of energy", say = true)
             state = CreepState.GET_ENERGY
         }
     }

--- a/src/main/kotlin/screepsai/Role.kt
+++ b/src/main/kotlin/screepsai/Role.kt
@@ -24,10 +24,35 @@ abstract class Role(val creep: Creep) {
             creep.memory.state = value.ordinal
         }
 
+    private fun log(level: String, message: String, say: Boolean = false) {
+        if (say) {
+            creep.say(message)
+        }
+        console.log("$level ${creep.name}: $message")
+    }
+
+    fun debug(message: String, say: Boolean = false) {
+        log("DEBUG", message, say = say)
+    }
+
+    fun info(message: String, say: Boolean = false) {
+        log("INFO", message, say = say)
+    }
+
+    fun warning(message: String, say: Boolean = false) {
+        log("WARNING", message, say = say)
+    }
+
+    fun error(message: String, say: Boolean = false) {
+        log("ERROR", message, say = say)
+    }
+
     abstract fun run()
 }
 
 enum class ScreepRole {
-    HARVESTER
+    HARVESTER,
+    TRANSPORTER,
+    UPGRADER
 }
 

--- a/src/main/kotlin/screepsai/Role.kt
+++ b/src/main/kotlin/screepsai/Role.kt
@@ -5,14 +5,21 @@ import screeps.api.CreepMemory
 import screeps.utils.memory.memory
 
 var CreepMemory.state: Int by memory { CreepState.GET_ENERGY.ordinal }
+var CreepMemory.role: Int by memory { CreepRole.UNASSIGNED.ordinal }
+
+enum class CreepRole {
+    UNASSIGNED,
+    HARVESTER,
+}
 
 enum class CreepState {
     GET_ENERGY,
     DO_WORK;
 }
 
-fun getState(state: Int): CreepState {
 
+fun getState(state: Int): CreepState {
+    // TODO: Set up a map so this is faster/better
     return CreepState.values().firstOrNull { it.ordinal == state } ?: CreepState.GET_ENERGY
 }
 
@@ -50,9 +57,15 @@ abstract class Role(val creep: Creep) {
     abstract fun run()
 }
 
-enum class ScreepRole {
-    HARVESTER,
-    TRANSPORTER,
-    UPGRADER
+
+// setRole and setRole are needed before any Role instances are set up
+// So set them as methods on the creep itself
+fun Creep.setRole(newRole: CreepRole) {
+    this.memory.role = newRole.ordinal
+}
+
+fun Creep.getRole(): CreepRole {
+    // TODO: Set up a map so this is faster/better
+    return CreepRole.values().firstOrNull {it.ordinal == memory.role} ?: CreepRole.UNASSIGNED
 }
 

--- a/src/main/kotlin/screepsai/SimpleAI.kt
+++ b/src/main/kotlin/screepsai/SimpleAI.kt
@@ -7,7 +7,15 @@ import screepsai.roles.*
 
 
 fun getCreepsByRole(): Map<CreepRole, List<Creep>> {
-    return Game.creeps.values.groupBy { it.getRole() }
+    val creepsByRole = Game.creeps.values.groupBy { it.getRole() }.toMutableMap()
+
+    for (creepRole in CreepRole.values()) {
+        if (!creepsByRole.containsKey(creepRole)) {
+            creepsByRole[creepRole] = listOf()
+        }
+    }
+
+    return creepsByRole
 }
 
 // Desired number of creeps in each role

--- a/src/main/kotlin/screepsai/SimpleAI.kt
+++ b/src/main/kotlin/screepsai/SimpleAI.kt
@@ -4,6 +4,8 @@ package screepsai
 import screeps.api.*
 import screeps.api.structures.StructureSpawn
 
+import screepsai.roles.*
+
 fun gameLoop() {
     val mainSpawn: StructureSpawn = Game.spawns.values.firstOrNull() ?: return
 

--- a/src/main/kotlin/screepsai/SimpleAI.kt
+++ b/src/main/kotlin/screepsai/SimpleAI.kt
@@ -7,21 +7,18 @@ import screepsai.roles.*
 
 
 fun getCreepsByRole(): Map<CreepRole, List<Creep>> {
-    val creepsByRole = Game.creeps.values.groupBy { it.getRole() }.toMutableMap()
 
-    for (creepRole in CreepRole.values()) {
-        if (!creepsByRole.containsKey(creepRole)) {
-            creepsByRole[creepRole] = listOf()
-        }
-    }
+    val creepsByRole = CreepRole.values().associateWith { listOf<Creep>() }.toMutableMap()
 
+    Game.creeps.values.groupBy { it.getRole() }.forEach { creepsByRole[it.key] = it.value }
     return creepsByRole
 }
 
 // Desired number of creeps in each role
 val roleMemberCount = mapOf(
     CreepRole.HARVESTER to 3,
-    CreepRole.UPGRADER to 6
+    CreepRole.UPGRADER to 8,
+    CreepRole.TRANSPORTER to 1
 )
 
 

--- a/src/main/kotlin/screepsai/SimpleAI.kt
+++ b/src/main/kotlin/screepsai/SimpleAI.kt
@@ -12,7 +12,8 @@ fun getCreepsByRole(): Map<CreepRole, List<Creep>> {
 
 // Desired number of creeps in each role
 val roleMemberCount = mapOf(
-    CreepRole.HARVESTER to 8
+    CreepRole.HARVESTER to 3,
+    CreepRole.UPGRADER to 6
 )
 
 

--- a/src/main/kotlin/screepsai/SimpleAI.kt
+++ b/src/main/kotlin/screepsai/SimpleAI.kt
@@ -11,10 +11,13 @@ fun gameLoop() {
     houseKeeping(Game.creeps)
 
     //make sure we have at least some creeps
-    spawnCreeps(ScreepRole.HARVESTER, mainSpawn)
+    spawnCreeps(CreepRole.HARVESTER, mainSpawn)
 
     for ((_, creep) in Game.creeps) {
-        val role = Harvester(creep)
+        val role = when (creep.getRole()){
+            CreepRole.HARVESTER-> Harvester(creep)
+            else -> Harvester(creep)
+        }
 
         role.run()
     }

--- a/src/main/kotlin/screepsai/Spawning.kt
+++ b/src/main/kotlin/screepsai/Spawning.kt
@@ -24,14 +24,21 @@ class Body(val parts: Array<BodyPartConstant>) {
 val BASE_BODY = Body(arrayOf(WORK, MOVE, CARRY))
 
 val HARVESTER_BODIES = arrayOf(
-    BASE_BODY,
+    Body(arrayOf(WORK, WORK, MOVE)),
+)
+
+val UPGRADER_BODIES = arrayOf(
+    Body(arrayOf(WORK, MOVE, MOVE, CARRY, CARRY))
 )
 
 fun getBody(role: CreepRole, energyAvailable: Int): Body {
-    return when (role) {
-        CreepRole.HARVESTER -> HARVESTER_BODIES.last { it.cost <= energyAvailable }
-        CreepRole.UNASSIGNED -> BASE_BODY
+    val bodies = when (role) {
+        CreepRole.HARVESTER -> HARVESTER_BODIES
+        CreepRole.UPGRADER -> UPGRADER_BODIES
+        CreepRole.UNASSIGNED -> return BASE_BODY
     }
+
+    return bodies.last { it.cost <= energyAvailable }
 }
 
 fun spawnCreeps(

--- a/src/main/kotlin/screepsai/Spawning.kt
+++ b/src/main/kotlin/screepsai/Spawning.kt
@@ -31,11 +31,16 @@ val UPGRADER_BODIES = arrayOf(
     Body(arrayOf(WORK, MOVE, MOVE, CARRY, CARRY))
 )
 
+val TRANSPORTER_BODIES = arrayOf(
+    Body(arrayOf(MOVE, MOVE, MOVE, CARRY, CARRY, CARRY))
+)
+
 fun getBody(role: CreepRole, energyAvailable: Int): Body {
     val bodies = when (role) {
+        CreepRole.UNASSIGNED -> return BASE_BODY
         CreepRole.HARVESTER -> HARVESTER_BODIES
         CreepRole.UPGRADER -> UPGRADER_BODIES
-        CreepRole.UNASSIGNED -> return BASE_BODY
+        CreepRole.TRANSPORTER -> TRANSPORTER_BODIES
     }
 
     return bodies.last { it.cost <= energyAvailable }
@@ -53,11 +58,10 @@ fun spawnCreeps(
     }
 
     val newName = "creep_${role.name}_${Game.time}"
-
     val code = spawn.spawnCreep(body.parts, newName)
     when (code) {
         OK -> console.log("spawning $newName with body $body")
-        ERR_BUSY, ERR_NOT_ENOUGH_ENERGY -> console.log("Not enough energy")
+        ERR_BUSY, ERR_NOT_ENOUGH_ENERGY -> console.log("Not enough energy to spawn a new ${role.name}")
         else -> console.log("unhandled error code $code")
     }
 

--- a/src/main/kotlin/screepsai/Spawning.kt
+++ b/src/main/kotlin/screepsai/Spawning.kt
@@ -26,14 +26,15 @@ val HARVESTER_BODIES = arrayOf(
     BASE_BODY,
 )
 
-fun getBody(role: ScreepRole, energyAvailable: Int): Body {
-    when (role) {
-        ScreepRole.HARVESTER -> return HARVESTER_BODIES.last { it.cost <= energyAvailable }
+fun getBody(role: CreepRole, energyAvailable: Int): Body {
+    return when (role) {
+        CreepRole.HARVESTER -> HARVESTER_BODIES.last { it.cost <= energyAvailable }
+        CreepRole.UNASSIGNED -> BASE_BODY
     }
 }
 
 fun spawnCreeps(
-    role: ScreepRole,
+    role: CreepRole,
     spawn: StructureSpawn
 ) {
 
@@ -43,13 +44,21 @@ fun spawnCreeps(
         BASE_BODY
     }
 
-    val newName = "creep_${Game.time}"
+    val newName = "creep_${role.name}_${Game.time}"
 
-    when (val code = spawn.spawnCreep(body.parts, newName)) {
+    val code = spawn.spawnCreep(body.parts, newName)
+    when (code) {
         OK -> console.log("spawning $newName with body $body")
-        ERR_BUSY, ERR_NOT_ENOUGH_ENERGY -> run { console.log("Not enough energy") }
+        ERR_BUSY, ERR_NOT_ENOUGH_ENERGY -> console.log("Not enough energy")
         else -> console.log("unhandled error code $code")
     }
+
+    if (code != OK) {
+        return
+    }
+
+    val creep = Game.creeps[newName]!!
+    creep.setRole(role)
 }
 
 fun houseKeeping(creeps: Record<String, Creep>) {

--- a/src/main/kotlin/screepsai/Spawning.kt
+++ b/src/main/kotlin/screepsai/Spawning.kt
@@ -4,6 +4,7 @@ import screeps.api.*
 import screeps.api.structures.StructureSpawn
 import screeps.utils.isEmpty
 import screeps.utils.unsafe.delete
+import screepsai.roles.*
 
 val BODYPART_COST = hashMapOf(
     MOVE to 50,

--- a/src/main/kotlin/screepsai/roles/Harvester.kt
+++ b/src/main/kotlin/screepsai/roles/Harvester.kt
@@ -4,18 +4,10 @@ import screeps.api.*
 
 class Harvester(creep: Creep) : Role(creep) {
     override fun run() {
-        debug("State = ${state.name}")
-        when (state) {
-            CreepState.GET_ENERGY -> {
-                getEnergy()
-            }
-            CreepState.DO_WORK -> {
-                storeEnergy()
-            }
-        }
+        harvestEnergy()
     }
 
-    private fun getEnergy() {
+    private fun harvestEnergy() {
         val energySources = creep.room.find(FIND_SOURCES)
         val energySource = energySources.first()
 
@@ -25,37 +17,6 @@ class Harvester(creep: Creep) : Role(creep) {
             creep.moveTo(energySource.pos.x, energySource.pos.y)
         } else if (status != OK) {
             error("Gather failed with code $status")
-        }
-
-        if (creep.store.getFreeCapacity() == 0) {
-            info("Energy full", say = true)
-            state = CreepState.DO_WORK
-        }
-    }
-
-    private fun storeEnergy() {
-        val controller = creep.room.controller
-
-        if (controller == null) {
-            error("No controller!", say = true)
-            return
-        }
-
-        val status = creep.upgradeController(controller)
-
-        if (status == ERR_NOT_IN_RANGE) {
-            creep.moveTo(controller)
-        } else if (status == ERR_NOT_ENOUGH_ENERGY) {
-            info("Out of energy", say = true)
-            state = CreepState.GET_ENERGY
-            return
-        } else if (status != OK) {
-            error("Upgrade failed with code $status")
-        }
-
-        if (creep.store.getCapacity(RESOURCE_ENERGY) <= 0) {
-            info("Out of energy", say = true)
-            state = CreepState.GET_ENERGY
         }
     }
 }

--- a/src/main/kotlin/screepsai/roles/Harvester.kt
+++ b/src/main/kotlin/screepsai/roles/Harvester.kt
@@ -1,4 +1,4 @@
-package screepsai
+package screepsai.roles
 
 import screeps.api.*
 

--- a/src/main/kotlin/screepsai/roles/Role.kt
+++ b/src/main/kotlin/screepsai/roles/Role.kt
@@ -9,7 +9,8 @@ var CreepMemory.role: Int by memory { CreepRole.UNASSIGNED.ordinal }
 enum class CreepRole {
     UNASSIGNED,
     HARVESTER,
-    UPGRADER
+    TRANSPORTER,
+    UPGRADER,
 }
 
 enum class CreepState {
@@ -31,9 +32,10 @@ abstract class Role(val creep: Creep) {
          */
         fun build(creepRole: CreepRole, creep: Creep): Role {
             return when (creepRole) {
+                CreepRole.UNASSIGNED -> Harvester(creep)
                 CreepRole.HARVESTER -> Harvester(creep)
                 CreepRole.UPGRADER -> Upgrader(creep)
-                CreepRole.UNASSIGNED -> Harvester(creep)
+                CreepRole.TRANSPORTER -> Transporter(creep)
             }
         }
     }

--- a/src/main/kotlin/screepsai/roles/Role.kt
+++ b/src/main/kotlin/screepsai/roles/Role.kt
@@ -24,6 +24,18 @@ fun getState(state: Int): CreepState {
 
 
 abstract class Role(val creep: Creep) {
+    companion object {
+        /*
+            Instantiate concrete subclass based on given role and creep
+         */
+        fun build(creepRole: CreepRole, creep: Creep): Role {
+            return when (creepRole) {
+                CreepRole.HARVESTER -> Harvester(creep)
+                else -> Harvester(creep)
+            }
+        }
+    }
+
     var state: CreepState = getState(creep.memory.state)
         set(value) {
             field = value

--- a/src/main/kotlin/screepsai/roles/Role.kt
+++ b/src/main/kotlin/screepsai/roles/Role.kt
@@ -1,7 +1,6 @@
-package screepsai
+package screepsai.roles
 
-import screeps.api.Creep
-import screeps.api.CreepMemory
+import screeps.api.*
 import screeps.utils.memory.memory
 
 var CreepMemory.state: Int by memory { CreepState.GET_ENERGY.ordinal }
@@ -66,6 +65,6 @@ fun Creep.setRole(newRole: CreepRole) {
 
 fun Creep.getRole(): CreepRole {
     // TODO: Set up a map so this is faster/better
-    return CreepRole.values().firstOrNull {it.ordinal == memory.role} ?: CreepRole.UNASSIGNED
+    return CreepRole.values().firstOrNull { it.ordinal == memory.role } ?: CreepRole.UNASSIGNED
 }
 

--- a/src/main/kotlin/screepsai/roles/Role.kt
+++ b/src/main/kotlin/screepsai/roles/Role.kt
@@ -9,6 +9,7 @@ var CreepMemory.role: Int by memory { CreepRole.UNASSIGNED.ordinal }
 enum class CreepRole {
     UNASSIGNED,
     HARVESTER,
+    UPGRADER
 }
 
 enum class CreepState {
@@ -31,7 +32,8 @@ abstract class Role(val creep: Creep) {
         fun build(creepRole: CreepRole, creep: Creep): Role {
             return when (creepRole) {
                 CreepRole.HARVESTER -> Harvester(creep)
-                else -> Harvester(creep)
+                CreepRole.UPGRADER -> Upgrader(creep)
+                CreepRole.UNASSIGNED -> Harvester(creep)
             }
         }
     }
@@ -63,6 +65,25 @@ abstract class Role(val creep: Creep) {
 
     fun error(message: String, say: Boolean = false) {
         log("ERROR", message, say = say)
+    }
+
+    protected fun pickupEnergy() {
+        // TODO: Handle priority
+        val energySources = creep.room.find(FIND_DROPPED_RESOURCES).filter { it.resourceType == RESOURCE_ENERGY }
+
+        if (energySources.isEmpty()) {
+            warning("No energy available!", say = true)
+            return
+        }
+
+        val energySource = energySources.first()
+        val status = creep.pickup(energySource)
+
+        if (status == ERR_NOT_IN_RANGE) {
+            creep.moveTo(energySource.pos.x, energySource.pos.y)
+        } else if (status != OK) {
+            error("Gather failed with code $status")
+        }
     }
 
     abstract fun run()

--- a/src/main/kotlin/screepsai/roles/Transporter.kt
+++ b/src/main/kotlin/screepsai/roles/Transporter.kt
@@ -1,0 +1,46 @@
+package screepsai.roles
+
+import screeps.api.*
+
+class Transporter(creep: Creep) : Role(creep) {
+    override fun run() {
+        when (state) {
+            CreepState.GET_ENERGY -> {
+                getEnergy()
+            }
+            CreepState.DO_WORK -> {
+                storeEnergy()
+            }
+        }
+    }
+
+    private fun getEnergy() {
+        pickupEnergy()
+
+        if (creep.store.getFreeCapacity() == 0) {
+            info("Energy full", say = true)
+            state = CreepState.DO_WORK
+        }
+    }
+
+    private fun storeEnergy() {
+        // TODO: Find other targets like extensions and storage
+        val spawn = creep.room.find(FIND_MY_SPAWNS).first()
+
+        val status = creep.transfer(spawn, RESOURCE_ENERGY)
+
+        if (status == ERR_NOT_IN_RANGE) {
+            creep.moveTo(spawn)
+        } else if (status == ERR_NOT_ENOUGH_ENERGY) {
+            info("Out of energy", say = true)
+            state = CreepState.GET_ENERGY
+            return
+        } else if (status != OK) {
+            error("Transfer failed with code $status", say = true)
+        }
+
+        if (creep.store.getCapacity(RESOURCE_ENERGY) <= 0) {
+            state = CreepState.GET_ENERGY
+        }
+    }
+}

--- a/src/main/kotlin/screepsai/roles/Upgrader.kt
+++ b/src/main/kotlin/screepsai/roles/Upgrader.kt
@@ -1,0 +1,50 @@
+package screepsai.roles
+
+import screeps.api.*
+
+class Upgrader(creep: Creep) : Role(creep) {
+    override fun run() {
+        when (state) {
+            CreepState.GET_ENERGY -> {
+                getEnergy()
+            }
+            CreepState.DO_WORK -> {
+                upgradeController()
+            }
+        }
+    }
+
+    private fun getEnergy() {
+        pickupEnergy()
+
+        if (creep.store.getFreeCapacity() == 0) {
+            info("Energy full", say = true)
+            state = CreepState.DO_WORK
+        }
+    }
+
+    private fun upgradeController() {
+        val controller = creep.room.controller
+
+        if (controller == null) {
+            error("No controller!")
+            return
+        }
+
+        val status = creep.upgradeController(controller)
+
+        if (status == ERR_NOT_IN_RANGE) {
+            creep.moveTo(controller)
+        } else if (status == ERR_NOT_ENOUGH_ENERGY) {
+            info("Out of energy", say = true)
+            state = CreepState.GET_ENERGY
+            return
+        } else if (status != OK) {
+            error("Upgrade failed with code $status", say = true)
+        }
+
+        if (creep.store.getCapacity(RESOURCE_ENERGY) <= 0) {
+            state = CreepState.GET_ENERGY
+        }
+    }
+}


### PR DESCRIPTION
Also adds a couple of basic roles.

## Description
We now have 3 roles
* Harvester - gathers energy from sources, drops on floor
* Transport - picks up energy on the floor, transports to spawn
* Upgrader - picks up energy on floor, upgrades room controller

The room will try to keep a specific number of creep in each role
* 3 Harvesters
* 1 Transporter
* 8 Upgraders

The spawning algorithm should prefer to replace Harvesters before Transporters and Transporters before Upgraders.

## Potential Issues

When a room is wiped completely clean of all creeps, the spawning algorithm will create all 3 Harvesters before making a Transporter or Upgrader. For now, the energy cost of the Harvesters is low enough that the spawner can passively generate enough energy to make all 3 Harvesters and a Transporter before the creeps start to expire. This will take a while though and a lot of energy will be wasted due to it sitting on the floor.

## Adding new roles

Creating a new role is very simple. 

* Create a new subclass of `Role`
* Create new `CreepRole` enum value for the new `Role` subclass
* Add line to `build` method of `Role` companion object to instantiate new `Role` subclass
* Add bodies for new `Role` in `Spawning.kt`
* Add case to select new bodies for role in `getBody`

Closes #5 
Closes #7 