### PR TITLE
Add builder role

### DIFF
--- a/src/main/kotlin/screepsai/SimpleAI.kt
+++ b/src/main/kotlin/screepsai/SimpleAI.kt
@@ -17,8 +17,9 @@ fun getCreepsByRole(): Map<CreepRole, List<Creep>> {
 // Desired number of creeps in each role
 val roleMemberCount = mapOf(
     CreepRole.HARVESTER to 3,
-    CreepRole.UPGRADER to 8,
-    CreepRole.TRANSPORTER to 1
+    CreepRole.UPGRADER to 2,
+    CreepRole.TRANSPORTER to 1,
+    CreepRole.BUILDER to 5
 )
 
 

--- a/src/main/kotlin/screepsai/SimpleAI.kt
+++ b/src/main/kotlin/screepsai/SimpleAI.kt
@@ -17,9 +17,9 @@ fun getCreepsByRole(): Map<CreepRole, List<Creep>> {
 // Desired number of creeps in each role
 val roleMemberCount = mapOf(
     CreepRole.HARVESTER to 3,
-    CreepRole.UPGRADER to 2,
+    CreepRole.UPGRADER to 8,
     CreepRole.TRANSPORTER to 1,
-    CreepRole.BUILDER to 5
+    CreepRole.BUILDER to 1
 )
 
 

--- a/src/main/kotlin/screepsai/Spawning.kt
+++ b/src/main/kotlin/screepsai/Spawning.kt
@@ -35,12 +35,17 @@ val TRANSPORTER_BODIES = arrayOf(
     Body(arrayOf(MOVE, MOVE, MOVE, CARRY, CARRY, CARRY))
 )
 
+val BUILDER_BODIES = arrayOf(
+    Body(arrayOf(WORK, WORK, CARRY, MOVE))
+)
+
 fun getBody(role: CreepRole, energyAvailable: Int): Body {
     val bodies = when (role) {
         CreepRole.UNASSIGNED -> return BASE_BODY
         CreepRole.HARVESTER -> HARVESTER_BODIES
         CreepRole.UPGRADER -> UPGRADER_BODIES
         CreepRole.TRANSPORTER -> TRANSPORTER_BODIES
+        CreepRole.BUILDER -> BUILDER_BODIES
     }
 
     return bodies.last { it.cost <= energyAvailable }

--- a/src/main/kotlin/screepsai/roles/Builder.kt
+++ b/src/main/kotlin/screepsai/roles/Builder.kt
@@ -1,0 +1,84 @@
+package screepsai.roles
+
+import screeps.api.*
+
+val MAINTENANCE_REQUIRED_BUILDING_TYPES = setOf(
+    STRUCTURE_ROAD,
+    STRUCTURE_STORAGE
+)
+
+class Builder(creep: Creep) : Role(creep) {
+    override fun run() {
+        when (state) {
+            CreepState.GET_ENERGY -> {
+                getEnergy()
+            }
+            CreepState.DO_WORK -> {
+                buildBuildings()
+            }
+        }
+    }
+
+    private fun getEnergy() {
+        pickupEnergy()
+
+        if (creep.store.getFreeCapacity() == 0) {
+            info("Energy full", say = true)
+            state = CreepState.DO_WORK
+        }
+    }
+
+    private fun buildBuildings() {
+        val constructionSite = creep.pos.findClosestByPath(FIND_CONSTRUCTION_SITES)
+
+        if (constructionSite == null) {
+            debug("No available construction sites!")
+            // Fall back to repairing buildings if there are none that need to be built
+            repairBuildings()
+            return
+        }
+
+        val status = creep.build(constructionSite)
+
+        if (status == ERR_NOT_IN_RANGE) {
+            creep.moveTo(constructionSite)
+        } else if (status == ERR_NOT_ENOUGH_ENERGY) {
+            info("Out of energy", say = true)
+            state = CreepState.GET_ENERGY
+            return
+        } else if (status != OK) {
+            error("Build failed with code $status", say = true)
+        }
+
+        if (creep.store.getCapacity(RESOURCE_ENERGY) <= 0) {
+            state = CreepState.GET_ENERGY
+        }
+    }
+
+    private fun repairBuildings() {
+        val building =
+            creep.room.find(FIND_STRUCTURES).filter { it.structureType in MAINTENANCE_REQUIRED_BUILDING_TYPES }
+                .minByOrNull { it.hits.toFloat() / it.hitsMax.toFloat() }
+
+        if (building == null) {
+            error("No available buildings to repair!")
+            return
+        }
+
+        val status = creep.repair(building)
+
+        if (status == ERR_NOT_IN_RANGE) {
+            creep.moveTo(building)
+        } else if (status == ERR_NOT_ENOUGH_ENERGY) {
+            info("Out of energy", say = true)
+            state = CreepState.GET_ENERGY
+            return
+        } else if (status != OK) {
+            error("Repair failed with code $status", say = true)
+        }
+
+        if (creep.store.getCapacity(RESOURCE_ENERGY) <= 0) {
+            state = CreepState.GET_ENERGY
+        }
+    }
+}

--- a/src/main/kotlin/screepsai/roles/Role.kt
+++ b/src/main/kotlin/screepsai/roles/Role.kt
@@ -11,6 +11,7 @@ enum class CreepRole {
     HARVESTER,
     TRANSPORTER,
     UPGRADER,
+    BUILDER,
 }
 
 enum class CreepState {
@@ -36,6 +37,7 @@ abstract class Role(val creep: Creep) {
                 CreepRole.HARVESTER -> Harvester(creep)
                 CreepRole.UPGRADER -> Upgrader(creep)
                 CreepRole.TRANSPORTER -> Transporter(creep)
+                CreepRole.BUILDER -> Builder(creep)
             }
         }
     }


### PR DESCRIPTION
Adds a simple builder role responsible for building new structures and repairing existing ones.

This also includes added logic to the transporter to fill extensions and storage with energy now that the screeps are capable of building them.

The other roles are not yet aware of the storage container in the room, so left as-is with a storage container in a room, the AI as of this PR will continue to fill the container without every pulling energy out of it.

closes #6 
closes #22 
closes #23 
closes #24 