### PR TITLE
Use storage

### DIFF
--- a/src/main/kotlin/screepsai/SimpleAI.kt
+++ b/src/main/kotlin/screepsai/SimpleAI.kt
@@ -16,10 +16,10 @@ fun getCreepsByRole(): Map<CreepRole, List<Creep>> {
 
 // Desired number of creeps in each role
 val roleMemberCount = mapOf(
-    CreepRole.HARVESTER to 3,
+    CreepRole.HARVESTER to 1,
     CreepRole.UPGRADER to 8,
-    CreepRole.TRANSPORTER to 1,
-    CreepRole.BUILDER to 1
+    CreepRole.TRANSPORTER to 2,
+    CreepRole.BUILDER to 4
 )
 
 

--- a/src/main/kotlin/screepsai/Spawning.kt
+++ b/src/main/kotlin/screepsai/Spawning.kt
@@ -25,27 +25,31 @@ val BASE_BODY = Body(arrayOf(WORK, MOVE, CARRY))
 
 val HARVESTER_BODIES = arrayOf(
     Body(arrayOf(WORK, WORK, MOVE)),
+    Body(arrayOf(WORK, WORK, WORK, WORK, WORK, MOVE)),
 )
 
 val UPGRADER_BODIES = arrayOf(
-    Body(arrayOf(WORK, MOVE, MOVE, CARRY, CARRY))
+    Body(arrayOf(WORK, MOVE, MOVE, CARRY, CARRY)),
+    Body(arrayOf(MOVE, WORK, WORK, WORK, CARRY, CARRY, CARRY, CARRY))
 )
 
 val TRANSPORTER_BODIES = arrayOf(
-    Body(arrayOf(MOVE, MOVE, MOVE, CARRY, CARRY, CARRY))
+    Body(arrayOf(MOVE, MOVE, CARRY, CARRY, CARRY, CARRY)),
+    Body(arrayOf(MOVE, MOVE, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY, CARRY))
 )
 
 val BUILDER_BODIES = arrayOf(
-    Body(arrayOf(WORK, WORK, CARRY, MOVE))
+    Body(arrayOf(WORK, WORK, CARRY, MOVE)),
+    Body(arrayOf(MOVE, MOVE, WORK, WORK, CARRY, CARRY, CARRY, CARRY, CARRY))
 )
 
 fun getBody(role: CreepRole, energyAvailable: Int): Body {
     val bodies = when (role) {
-        CreepRole.UNASSIGNED -> return BASE_BODY
-        CreepRole.HARVESTER -> HARVESTER_BODIES
-        CreepRole.UPGRADER -> UPGRADER_BODIES
+        CreepRole.UNASSIGNED  -> return BASE_BODY
+        CreepRole.HARVESTER   -> HARVESTER_BODIES
+        CreepRole.UPGRADER    -> UPGRADER_BODIES
         CreepRole.TRANSPORTER -> TRANSPORTER_BODIES
-        CreepRole.BUILDER -> BUILDER_BODIES
+        CreepRole.BUILDER     -> BUILDER_BODIES
     }
 
     return bodies.last { it.cost <= energyAvailable }
@@ -58,16 +62,17 @@ fun spawnCreeps(
 
     val body = try {
         getBody(role, spawn.room.energyCapacityAvailable)
-    } catch (error: NoSuchElementException) {
+    }
+    catch (error: NoSuchElementException) {
         BASE_BODY
     }
 
     val newName = "creep_${role.name}_${Game.time}"
     val code = spawn.spawnCreep(body.parts, newName)
     when (code) {
-        OK -> console.log("spawning $newName with body $body")
+        OK                              -> console.log("spawning $newName with body $body")
         ERR_BUSY, ERR_NOT_ENOUGH_ENERGY -> console.log("Not enough energy to spawn a new ${role.name}")
-        else -> console.log("unhandled error code $code")
+        else                            -> console.log("unhandled error code $code")
     }
 
     if (code != OK) {

--- a/src/main/kotlin/screepsai/roles/Builder.kt
+++ b/src/main/kotlin/screepsai/roles/Builder.kt
@@ -12,19 +12,31 @@ class Builder(creep: Creep) : Role(creep) {
         when (state) {
             CreepState.GET_ENERGY -> {
                 getEnergy()
+                if (creep.store.getFreeCapacity() == 0) {
+                    info("Energy full", say = true)
+                    state = CreepState.DO_WORK
+                }
             }
-            CreepState.DO_WORK -> {
+            CreepState.DO_WORK    -> {
                 buildBuildings()
             }
         }
     }
 
     private fun getEnergy() {
-        pickupEnergy()
+        val storage = creep.room.storage
 
-        if (creep.store.getFreeCapacity() == 0) {
-            info("Energy full", say = true)
-            state = CreepState.DO_WORK
+        if (storage == null || (storage.store.getUsedCapacity(RESOURCE_ENERGY) ?: 0) <= 0) {
+            pickupEnergy()
+            return
+        }
+
+        val code = creep.withdraw(storage, RESOURCE_ENERGY)
+        if (code == ERR_NOT_IN_RANGE) {
+            creep.moveTo(storage)
+        }
+        else if (code != OK) {
+            error("Couldn't withdraw from storage due to error: $code")
         }
     }
 
@@ -42,11 +54,13 @@ class Builder(creep: Creep) : Role(creep) {
 
         if (status == ERR_NOT_IN_RANGE) {
             creep.moveTo(constructionSite)
-        } else if (status == ERR_NOT_ENOUGH_ENERGY) {
+        }
+        else if (status == ERR_NOT_ENOUGH_ENERGY) {
             info("Out of energy", say = true)
             state = CreepState.GET_ENERGY
             return
-        } else if (status != OK) {
+        }
+        else if (status != OK) {
             error("Build failed with code $status", say = true)
         }
 
@@ -69,11 +83,13 @@ class Builder(creep: Creep) : Role(creep) {
 
         if (status == ERR_NOT_IN_RANGE) {
             creep.moveTo(building)
-        } else if (status == ERR_NOT_ENOUGH_ENERGY) {
+        }
+        else if (status == ERR_NOT_ENOUGH_ENERGY) {
             info("Out of energy", say = true)
             state = CreepState.GET_ENERGY
             return
-        } else if (status != OK) {
+        }
+        else if (status != OK) {
             error("Repair failed with code $status", say = true)
         }
 

--- a/src/main/kotlin/screepsai/roles/Upgrader.kt
+++ b/src/main/kotlin/screepsai/roles/Upgrader.kt
@@ -7,19 +7,31 @@ class Upgrader(creep: Creep) : Role(creep) {
         when (state) {
             CreepState.GET_ENERGY -> {
                 getEnergy()
+                if (creep.store.getFreeCapacity() == 0) {
+                    info("Energy full", say = true)
+                    state = CreepState.DO_WORK
+                }
             }
-            CreepState.DO_WORK -> {
+            CreepState.DO_WORK    -> {
                 upgradeController()
             }
         }
     }
 
     private fun getEnergy() {
-        pickupEnergy()
+        val storage = creep.room.storage
 
-        if (creep.store.getFreeCapacity() == 0) {
-            info("Energy full", say = true)
-            state = CreepState.DO_WORK
+        if (storage == null || (storage.store.getUsedCapacity(RESOURCE_ENERGY) ?: 0) <= 0) {
+            pickupEnergy()
+            return
+        }
+
+        val code = creep.withdraw(storage, RESOURCE_ENERGY)
+        if (code == ERR_NOT_IN_RANGE) {
+            creep.moveTo(storage)
+        }
+        else if (code != OK) {
+            error("Couldn't withdraw from storage due to error: $code")
         }
     }
 
@@ -35,11 +47,13 @@ class Upgrader(creep: Creep) : Role(creep) {
 
         if (status == ERR_NOT_IN_RANGE) {
             creep.moveTo(controller)
-        } else if (status == ERR_NOT_ENOUGH_ENERGY) {
+        }
+        else if (status == ERR_NOT_ENOUGH_ENERGY) {
             info("Out of energy", say = true)
             state = CreepState.GET_ENERGY
             return
-        } else if (status != OK) {
+        }
+        else if (status != OK) {
             error("Upgrade failed with code $status", say = true)
         }
 


### PR DESCRIPTION
This PR makes the builders and upgraders prefer to grab energy from the storage instead of looking for dropped energy.

It also includes an update to the body arrays so that the spawner will start spawning "level 2" creeps to take advantage of a room with 5 extensions. Currently the room I'm playing with is at RCL 6 and has many more extensions, but I don't have any logic to manage waiting for extensions to be filled (or even know if there's hope for them to be filled) before spawning a creep. So there may be level 1 creeps spawned amongst the level 2 creeps if spawns are triggered before the transporters get a chance to fill extensions.

Closes #28 
Closes #8 