### PR TITLE
Harvest multiple energy sources

### DIFF
--- a/src/main/kotlin/screepsai/SimpleAI.kt
+++ b/src/main/kotlin/screepsai/SimpleAI.kt
@@ -19,8 +19,8 @@ val roleMemberCount = mapOf(
     CreepRole.HARVESTER to 2,
     CreepRole.TRANSPORTER to 2,
     CreepRole.MAINTAINER to 2,
-    CreepRole.UPGRADER to 8,
-    CreepRole.BUILDER to 2
+    CreepRole.UPGRADER to 6,
+    CreepRole.BUILDER to 1
 )
 
 

--- a/src/main/kotlin/screepsai/SimpleAI.kt
+++ b/src/main/kotlin/screepsai/SimpleAI.kt
@@ -7,11 +7,7 @@ import screepsai.roles.*
 
 
 fun getCreepsByRole(): Map<CreepRole, List<Creep>> {
-
-    val creepsByRole = CreepRole.values().associateWith { listOf<Creep>() }.toMutableMap()
-
-    Game.creeps.values.groupBy { it.getRole() }.forEach { creepsByRole[it.key] = it.value }
-    return creepsByRole
+    return Game.creeps.values.groupBy { it.getRole() }
 }
 
 // Desired number of creeps in each role
@@ -31,19 +27,51 @@ fun gameLoop() {
     //delete memories of creeps that have passed away
     houseKeeping(Game.creeps)
 
-    for (entry in getCreepsByRole()) {
-        console.log("${entry.key}: ${entry.value.size}")
-        val creepRole = entry.key
-        val creeps = entry.value
-        val creepCount = entry.value.size
+    val creepsByRole = getCreepsByRole()
+    for (roleCount in roleMemberCount) {
+        val creepRole = roleCount.key
+        val creepCount = creepsByRole[roleCount.key]?.size ?: 0
+        console.log("${creepRole}: ${creepCount}")
         // Spawn more creeps if we are not at the desired volume
-        if (creepCount < roleMemberCount[entry.key]) {
-            spawnCreeps(creepRole, mainSpawn)
+        if (creepCount < roleCount.value) {
+            // Don't spawn an extra creep in a role until every other role has same amount or reached the max
+            var spawn = true
+            for (creeps_in_role in creepsByRole) {
+                // Ignore same role we're trying to spawn
+                if (creepRole == creeps_in_role.key) {
+                    continue
+                }
+
+                // Ignore any roles already maxed out
+                if (creeps_in_role.value.size >= roleMemberCount[creeps_in_role.key]) {
+                    continue
+                }
+
+                // Detect when we have same or more than another role
+                if (creepCount > creeps_in_role.value.count()) {
+                    console.log("Not spawning ${creepRole} due to not enough ${creeps_in_role.key}")
+                    spawn = false
+                }
+            }
+            if (spawn) {
+                spawnCreeps(creepRole, mainSpawn)
+            }
         }
 
         // Set up role object and run role for each creep
+        val creeps = creepsByRole[roleCount.key] ?: listOf()
         for (creep in creeps) {
-            Role.build(creepRole, creep).run()
+            try {
+                Role.build(creepRole, creep).run()
+            }
+            catch (error: IllegalArgumentException) {
+                if (creep.body.any { it.type == WORK }) {
+                    creep.setRole(CreepRole.UPGRADER)
+                }
+                else {
+                    creep.setRole(CreepRole.TRANSPORTER)
+                }
+            }
         }
     }
 

--- a/src/main/kotlin/screepsai/SimpleAI.kt
+++ b/src/main/kotlin/screepsai/SimpleAI.kt
@@ -25,6 +25,7 @@ val roleMemberCount = mapOf(
 
 
 fun gameLoop() {
+    val startCpu = Game.cpu.tickLimit
     val mainSpawn: StructureSpawn = Game.spawns.values.firstOrNull() ?: return
 
     //delete memories of creeps that have passed away
@@ -45,4 +46,6 @@ fun gameLoop() {
             Role.build(creepRole, creep).run()
         }
     }
+
+    console.log("Used ${startCpu - Game.cpu.tickLimit} CPU on tick ${Game.time}")
 }

--- a/src/main/kotlin/screepsai/SimpleAI.kt
+++ b/src/main/kotlin/screepsai/SimpleAI.kt
@@ -20,7 +20,7 @@ val roleMemberCount = mapOf(
     CreepRole.TRANSPORTER to 2,
     CreepRole.MAINTAINER to 2,
     CreepRole.UPGRADER to 8,
-    CreepRole.BUILDER to 1
+    CreepRole.BUILDER to 2
 )
 
 

--- a/src/main/kotlin/screepsai/SimpleAI.kt
+++ b/src/main/kotlin/screepsai/SimpleAI.kt
@@ -16,10 +16,10 @@ fun getCreepsByRole(): Map<CreepRole, List<Creep>> {
 
 // Desired number of creeps in each role
 val roleMemberCount = mapOf(
-    CreepRole.HARVESTER to 1,
+    CreepRole.HARVESTER to 2,
     CreepRole.TRANSPORTER to 2,
     CreepRole.MAINTAINER to 2,
-    CreepRole.UPGRADER to 4,
+    CreepRole.UPGRADER to 8,
     CreepRole.BUILDER to 1
 )
 

--- a/src/main/kotlin/screepsai/SimpleAI.kt
+++ b/src/main/kotlin/screepsai/SimpleAI.kt
@@ -17,9 +17,10 @@ fun getCreepsByRole(): Map<CreepRole, List<Creep>> {
 // Desired number of creeps in each role
 val roleMemberCount = mapOf(
     CreepRole.HARVESTER to 1,
-    CreepRole.UPGRADER to 8,
     CreepRole.TRANSPORTER to 2,
-    CreepRole.BUILDER to 4
+    CreepRole.MAINTAINER to 2,
+    CreepRole.UPGRADER to 4,
+    CreepRole.BUILDER to 1
 )
 
 

--- a/src/main/kotlin/screepsai/Spawning.kt
+++ b/src/main/kotlin/screepsai/Spawning.kt
@@ -39,7 +39,7 @@ val TRANSPORTER_BODIES = arrayOf(
 )
 
 val BUILDER_BODIES = arrayOf(
-    Body(arrayOf(WORK, WORK, CARRY, MOVE)),
+    Body(arrayOf(WORK, CARRY, CARRY, CARRY, MOVE)),
     Body(arrayOf(MOVE, MOVE, WORK, WORK, CARRY, CARRY, CARRY, CARRY, CARRY))
 )
 
@@ -50,6 +50,7 @@ fun getBody(role: CreepRole, energyAvailable: Int): Body {
         CreepRole.UPGRADER    -> UPGRADER_BODIES
         CreepRole.TRANSPORTER -> TRANSPORTER_BODIES
         CreepRole.BUILDER     -> BUILDER_BODIES
+        CreepRole.MAINTAINER  -> BUILDER_BODIES
     }
 
     return bodies.last { it.cost <= energyAvailable }

--- a/src/main/kotlin/screepsai/Spawning.kt
+++ b/src/main/kotlin/screepsai/Spawning.kt
@@ -62,16 +62,17 @@ fun spawnCreeps(
 ) {
 
     val body = try {
-        getBody(role, spawn.room.energyCapacityAvailable)
+        getBody(role, spawn.room.energyAvailable)
     }
     catch (error: NoSuchElementException) {
-        BASE_BODY
+        console.log("Couldn't determine body for ${role} with ${spawn.room.energyAvailable} energy")
+        return
     }
 
     val newName = "creep_${role.name}_${Game.time}"
     val code = spawn.spawnCreep(body.parts, newName)
     when (code) {
-        OK                              -> console.log("spawning $newName with body $body")
+        OK                              -> console.log("spawning $newName with body ${body.parts}")
         ERR_BUSY, ERR_NOT_ENOUGH_ENERGY -> console.log("Not enough energy to spawn a new ${role.name}")
         else                            -> console.log("unhandled error code $code")
     }

--- a/src/main/kotlin/screepsai/roles/Builder.kt
+++ b/src/main/kotlin/screepsai/roles/Builder.kt
@@ -66,7 +66,8 @@ class Builder(creep: Creep) : Role(creep) {
 
     private fun repairBuildings() {
         val building =
-            creep.room.find(FIND_STRUCTURES).filter { it.structureType in MAINTENANCE_REQUIRED_BUILDING_TYPES }
+            creep.room.find(FIND_STRUCTURES)
+                .filter { it.structureType in MAINTENANCE_REQUIRED_BUILDING_TYPES || it.structureType == STRUCTURE_WALL }
                 .minByOrNull { it.hits.toFloat() / it.hitsMax.toFloat() }
 
         if (building == null) {

--- a/src/main/kotlin/screepsai/roles/Builder.kt
+++ b/src/main/kotlin/screepsai/roles/Builder.kt
@@ -68,7 +68,13 @@ class Builder(creep: Creep) : Role(creep) {
         val building =
             creep.room.find(FIND_STRUCTURES)
                 .filter { it.structureType in MAINTENANCE_REQUIRED_BUILDING_TYPES || it.structureType == STRUCTURE_WALL }
-                .minByOrNull { it.hits.toFloat() / it.hitsMax.toFloat() }
+                .minByOrNull {
+                    val ratio = it.hits.toFloat() / it.hitsMax.toFloat()
+
+                    // Chunk float into multiple levels so the creep is less sensitive to repair progress
+                    // this makes the creeps focus on repairing a single target until it moves into the next "bucket"
+                    (ratio * 1000).toInt()
+                }
 
         if (building == null) {
             error("No available buildings to repair!")

--- a/src/main/kotlin/screepsai/roles/Harvester.kt
+++ b/src/main/kotlin/screepsai/roles/Harvester.kt
@@ -1,21 +1,64 @@
 package screepsai.roles
 
 import screeps.api.*
+import screeps.utils.memory.memory
+
+var CreepMemory.energySource: String? by memory()
+var RoomMemory.energySourceAssignments: Array<String?> by memory { arrayOf(null, null) }
 
 class Harvester(creep: Creep) : Role(creep) {
+    private var assignedSource: Source? = Game.getObjectById(creep.memory.energySource)
+        set(value) {
+            creep.memory.energySource = value?.id
+            field = value
+        }
+
     override fun run() {
         harvestEnergy()
     }
 
+    private fun findEnergySource(): Source? {
+        if (assignedSource != null) {
+            return assignedSource as Source
+        }
+
+        val energySources = creep.room.find(FIND_SOURCES).sortedBy { it.id }
+
+        if (energySources.isEmpty()) {
+            error("There are no sources in the room!")
+            return null
+        }
+
+        for (energySource in energySources.withIndex()) {
+            val otherCreep = Game.getObjectById<Creep>(creep.room.memory.energySourceAssignments[energySource.index])
+            if (otherCreep == null) {
+                info("Dead creep found, re-assigning energy source")
+                assignedSource = energySource.value
+                creep.room.memory.energySourceAssignments[energySource.index] = creep.id
+                return assignedSource
+            }
+            else {
+                debug("Energy source already taken, checking other source(s)")
+            }
+        }
+
+        error("All sources in room are taken")
+        return null
+    }
+
     private fun harvestEnergy() {
-        val energySources = creep.room.find(FIND_SOURCES)
-        val energySource = energySources.first()
+        val energySource = findEnergySource()
+        if (energySource == null) {
+            error("No sources found to gather from!")
+            return
+        }
 
         val status = creep.harvest(energySource)
 
         if (status == ERR_NOT_IN_RANGE) {
             creep.moveTo(energySource.pos.x, energySource.pos.y)
-        } else if (status != OK) {
+        }
+        else if (status != OK) {
             error("Gather failed with code $status")
         }
     }

--- a/src/main/kotlin/screepsai/roles/Maintainer.kt
+++ b/src/main/kotlin/screepsai/roles/Maintainer.kt
@@ -36,13 +36,22 @@ class Maintainer(creep: Creep) : Role(creep) {
     }
 
     private fun repairBuildings() {
-        val building =
+        var building =
             creep.room.find(FIND_STRUCTURES).filter { it.structureType in MAINTENANCE_REQUIRED_BUILDING_TYPES }
                 .minByOrNull { it.hits.toFloat() / it.hitsMax.toFloat() }
 
         if (building == null) {
             error("No available buildings to repair!")
             return
+        }
+
+        if (building.hits.toFloat() / building.hitsMax.toFloat() > 0.90) {
+            info("Buildings well maintained, repairing a wall instead")
+            val wall = creep.room.find(FIND_MY_STRUCTURES).filter { it.structureType == STRUCTURE_WALL }
+                .minByOrNull { it.hits.toFloat() / it.hitsMax.toFloat() }
+            if (wall != null) {
+                building = wall
+            }
         }
 
         val status = creep.repair(building)

--- a/src/main/kotlin/screepsai/roles/Maintainer.kt
+++ b/src/main/kotlin/screepsai/roles/Maintainer.kt
@@ -52,8 +52,7 @@ class Maintainer(creep: Creep) : Role(creep) {
         }
 
         if (building.hits.toFloat() / building.hitsMax.toFloat() > 0.90) {
-            info("Buildings well maintained, repairing a wall instead")
-            val wall = creep.room.find(FIND_MY_STRUCTURES).filter { it.structureType == STRUCTURE_WALL }
+            val wall = creep.room.find(FIND_STRUCTURES).filter { it.structureType == STRUCTURE_WALL }
                 .minByOrNull {
                     val ratio = it.hits.toFloat() / it.hitsMax.toFloat()
                     // Chunk float into multiple levels so the creep is less sensitive to repair progress
@@ -61,6 +60,7 @@ class Maintainer(creep: Creep) : Role(creep) {
                     (ratio * 1000).toInt()
                 }
             if (wall != null) {
+                info("Buildings well maintained, repairing a wall instead")
                 building = wall
             }
         }

--- a/src/main/kotlin/screepsai/roles/Maintainer.kt
+++ b/src/main/kotlin/screepsai/roles/Maintainer.kt
@@ -38,7 +38,13 @@ class Maintainer(creep: Creep) : Role(creep) {
     private fun repairBuildings() {
         var building =
             creep.room.find(FIND_STRUCTURES).filter { it.structureType in MAINTENANCE_REQUIRED_BUILDING_TYPES }
-                .minByOrNull { it.hits.toFloat() / it.hitsMax.toFloat() }
+                .minByOrNull {
+                    val ratio = it.hits.toFloat() / it.hitsMax.toFloat()
+
+                    // Chunk float into multiple levels so the creep is less sensitive to repair progress
+                    // this makes the creeps focus on repairing a single target until it moves into the next "bucket"
+                    (ratio * 1000).toInt()
+                }
 
         if (building == null) {
             error("No available buildings to repair!")
@@ -48,7 +54,12 @@ class Maintainer(creep: Creep) : Role(creep) {
         if (building.hits.toFloat() / building.hitsMax.toFloat() > 0.90) {
             info("Buildings well maintained, repairing a wall instead")
             val wall = creep.room.find(FIND_MY_STRUCTURES).filter { it.structureType == STRUCTURE_WALL }
-                .minByOrNull { it.hits.toFloat() / it.hitsMax.toFloat() }
+                .minByOrNull {
+                    val ratio = it.hits.toFloat() / it.hitsMax.toFloat()
+                    // Chunk float into multiple levels so the creep is less sensitive to repair progress
+                    // this makes the creeps focus on repairing a single target until it moves into the next "bucket"
+                    (ratio * 1000).toInt()
+                }
             if (wall != null) {
                 building = wall
             }

--- a/src/main/kotlin/screepsai/roles/Maintainer.kt
+++ b/src/main/kotlin/screepsai/roles/Maintainer.kt
@@ -2,7 +2,7 @@ package screepsai.roles
 
 import screeps.api.*
 
-class Builder(creep: Creep) : Role(creep) {
+class Maintainer(creep: Creep) : Role(creep) {
     override fun run() {
         when (state) {
             CreepState.GET_ENERGY -> {
@@ -13,7 +13,7 @@ class Builder(creep: Creep) : Role(creep) {
                 }
             }
             CreepState.DO_WORK    -> {
-                buildBuildings()
+                repairBuildings()
             }
         }
     }
@@ -32,35 +32,6 @@ class Builder(creep: Creep) : Role(creep) {
         }
         else if (code != OK) {
             error("Couldn't withdraw from storage due to error: $code")
-        }
-    }
-
-    private fun buildBuildings() {
-        val constructionSite = creep.pos.findClosestByPath(FIND_CONSTRUCTION_SITES)
-
-        if (constructionSite == null) {
-            debug("No available construction sites!")
-            // Fall back to repairing buildings if there are none that need to be built
-            repairBuildings()
-            return
-        }
-
-        val status = creep.build(constructionSite)
-
-        if (status == ERR_NOT_IN_RANGE) {
-            creep.moveTo(constructionSite)
-        }
-        else if (status == ERR_NOT_ENOUGH_ENERGY) {
-            info("Out of energy", say = true)
-            state = CreepState.GET_ENERGY
-            return
-        }
-        else if (status != OK) {
-            error("Build failed with code $status", say = true)
-        }
-
-        if (creep.store.getCapacity(RESOURCE_ENERGY) <= 0) {
-            state = CreepState.GET_ENERGY
         }
     }
 

--- a/src/main/kotlin/screepsai/roles/Role.kt
+++ b/src/main/kotlin/screepsai/roles/Role.kt
@@ -12,12 +12,18 @@ enum class CreepRole {
     TRANSPORTER,
     UPGRADER,
     BUILDER,
+    MAINTAINER
 }
 
 enum class CreepState {
     GET_ENERGY,
     DO_WORK;
 }
+
+val MAINTENANCE_REQUIRED_BUILDING_TYPES = setOf(
+    STRUCTURE_ROAD,
+    STRUCTURE_STORAGE
+)
 
 
 fun getState(state: Int): CreepState {
@@ -33,11 +39,12 @@ abstract class Role(val creep: Creep) {
          */
         fun build(creepRole: CreepRole, creep: Creep): Role {
             return when (creepRole) {
-                CreepRole.UNASSIGNED -> Harvester(creep)
-                CreepRole.HARVESTER -> Harvester(creep)
-                CreepRole.UPGRADER -> Upgrader(creep)
+                CreepRole.UNASSIGNED  -> Harvester(creep)
+                CreepRole.HARVESTER   -> Harvester(creep)
+                CreepRole.UPGRADER    -> Upgrader(creep)
                 CreepRole.TRANSPORTER -> Transporter(creep)
-                CreepRole.BUILDER -> Builder(creep)
+                CreepRole.BUILDER     -> Builder(creep)
+                CreepRole.MAINTAINER  -> Maintainer(creep)
             }
         }
     }
@@ -85,7 +92,8 @@ abstract class Role(val creep: Creep) {
 
         if (status == ERR_NOT_IN_RANGE) {
             creep.moveTo(energySource.pos.x, energySource.pos.y)
-        } else if (status != OK) {
+        }
+        else if (status != OK) {
             error("Gather failed with code $status")
         }
     }

--- a/src/main/kotlin/screepsai/roles/Role.kt
+++ b/src/main/kotlin/screepsai/roles/Role.kt
@@ -2,6 +2,7 @@ package screepsai.roles
 
 import screeps.api.*
 import screeps.utils.memory.memory
+import kotlin.math.abs
 
 var CreepMemory.state: Int by memory { CreepState.GET_ENERGY.ordinal }
 var CreepMemory.role: Int by memory { CreepRole.UNASSIGNED.ordinal }
@@ -80,14 +81,14 @@ abstract class Role(val creep: Creep) {
 
     protected fun pickupEnergy() {
         // TODO: Handle priority
-        val energySources = creep.room.find(FIND_DROPPED_RESOURCES).filter { it.resourceType == RESOURCE_ENERGY }
+        val energySource = creep.room.find(FIND_DROPPED_RESOURCES).filter { it.resourceType == RESOURCE_ENERGY }
+            .minByOrNull { abs(creep.pos.x - it.pos.x) + abs(creep.pos.y - it.pos.y) / it.amount }
 
-        if (energySources.isEmpty()) {
+        if (energySource == null) {
             warning("No energy available!", say = true)
             return
         }
 
-        val energySource = energySources.first()
         val status = creep.pickup(energySource)
 
         if (status == ERR_NOT_IN_RANGE) {

--- a/src/main/kotlin/screepsai/roles/Role.kt
+++ b/src/main/kotlin/screepsai/roles/Role.kt
@@ -79,14 +79,14 @@ abstract class Role(val creep: Creep) {
         log("ERROR", message, say = say)
     }
 
-    protected fun pickupEnergy() {
+    protected fun pickupEnergy(): ScreepsReturnCode {
         // TODO: Handle priority
         val energySource = creep.room.find(FIND_DROPPED_RESOURCES).filter { it.resourceType == RESOURCE_ENERGY }
-            .minByOrNull { abs(creep.pos.x - it.pos.x) + abs(creep.pos.y - it.pos.y) / it.amount }
+            .minByOrNull { (abs(creep.pos.x - it.pos.x) + abs(creep.pos.y - it.pos.y)) / it.amount }
 
-        if (energySource == null) {
+        if (energySource == null || energySource.amount < 10) {
             warning("No energy available!", say = true)
-            return
+            return ERR_NOT_FOUND
         }
 
         val status = creep.pickup(energySource)
@@ -97,6 +97,7 @@ abstract class Role(val creep: Creep) {
         else if (status != OK) {
             error("Gather failed with code $status")
         }
+        return status
     }
 
     abstract fun run()

--- a/src/main/kotlin/screepsai/roles/Role.kt
+++ b/src/main/kotlin/screepsai/roles/Role.kt
@@ -40,7 +40,7 @@ abstract class Role(val creep: Creep) {
          */
         fun build(creepRole: CreepRole, creep: Creep): Role {
             return when (creepRole) {
-                CreepRole.UNASSIGNED  -> Harvester(creep)
+                CreepRole.UNASSIGNED  -> throw IllegalArgumentException("Cannot process a creep without a role")
                 CreepRole.HARVESTER   -> Harvester(creep)
                 CreepRole.UPGRADER    -> Upgrader(creep)
                 CreepRole.TRANSPORTER -> Transporter(creep)


### PR DESCRIPTION
This PR adds logic to harvesters to harvest from multiple energy sources.

It also add some minor improvements to creeps that pick up energy to try and grab from the closest pile.

This change also includes a new `Maintainer` role that functions similar to the builder, but only seeks to repair existing buildings.

The final change in this PR is also some logic to target repairing walls now that there's a lot more energy available to the room.

Maintainers will only repair walls if all of the other structures in the room are well maintained. Builders will repair walls if there are no construction sites and the walls have the lowest health ratio (when  they are first build, they have 1/300 million hp, so they're the primary target for builders for a decent amount of time).

## Potential issues
Builders always seek the lowest health wall, so they end up building them all at equal speed. It would be more efficient for them to dump all of their energy on one wall before moving to the next one. Right now they spend a lot of time moving around between walls instead of building them. Maintainers have the same problem with roads and often drop just a single shot of energy into a road at a time,

closes #14 
closes #20 