### PR TITLE
Establish new rooms

### DIFF
--- a/src/main/kotlin/screepsai/GameLoop.kt
+++ b/src/main/kotlin/screepsai/GameLoop.kt
@@ -5,7 +5,6 @@ import screeps.api.*
 import screeps.api.structures.StructureTower
 import screepsai.roles.*
 
-
 fun getCreepsByRole(): Map<CreepRole, Map<Room, List<Creep>>> {
 
     val creepsByRoleAndRoom = HashMap<CreepRole, Map<Room, List<Creep>>>()
@@ -21,7 +20,7 @@ val roleMemberCount = mapOf(
     CreepRole.HARVESTER to 2,
     CreepRole.TRANSPORTER to 2,
     CreepRole.MAINTAINER to 2,
-    CreepRole.UPGRADER to 6,
+    CreepRole.UPGRADER to 8,
     CreepRole.BUILDER to 1
 )
 
@@ -49,7 +48,6 @@ fun runRoom(room: Room, creepsByRoleAndRoom: Map<CreepRole, Map<Room, List<Creep
     else {
         console.log("All roles filled in ${room}")
     }
-
 
     for (record in creepsByRole) {
         val creepRole = record.key
@@ -83,9 +81,19 @@ fun runRoom(room: Room, creepsByRoleAndRoom: Map<CreepRole, Map<Room, List<Creep
     }
 }
 
+fun claimNewRooms(creepsByRoomAndRole: Map<CreepRole, Map<Room, List<Creep>>>) {
+    val nextRoomFlag = Game.flags["NextRoom"] ?: return console.log("No NextRoom flag, skipping claim room routine")
+    val claimer =
+        creepsByRoomAndRole[CreepRole.CLAIMER]?.flatMap { it.value }?.firstOrNull() ?: spawnClaimer(nextRoomFlag)
+        ?: return console.log("No claimer creep could be located or created")
+
+    Role.build(CreepRole.CLAIMER, claimer).run()
+}
+
 
 fun gameLoop() {
     val startCpu = Game.cpu.tickLimit
+    console.log("${startCpu} CPU available on tick ${Game.time}")
     //delete memories of creeps that have passed away
     houseKeeping(Game.creeps)
 
@@ -97,6 +105,8 @@ fun gameLoop() {
         runRoom(room, creepsByRoomAndRole)
         console.log("${room} used ${roomStartCpu - Game.cpu.tickLimit} CPU on tick ${Game.time}")
     }
+
+    claimNewRooms(creepsByRoomAndRole)
 
     console.log("Used ${startCpu - Game.cpu.tickLimit} CPU on tick ${Game.time}")
 }

--- a/src/main/kotlin/screepsai/GameLoop.kt
+++ b/src/main/kotlin/screepsai/GameLoop.kt
@@ -77,6 +77,9 @@ fun runRoom(room: Room, creepsByRoleAndRoom: Map<CreepRole, Map<Room, List<Creep
                     creep.setRole(CreepRole.TRANSPORTER)
                 }
             }
+            catch (error: Exception) {
+                console.log("${creep.name} failed to run due to error: ${error}")
+            }
         }
     }
 }

--- a/src/main/kotlin/screepsai/GameLoop.kt
+++ b/src/main/kotlin/screepsai/GameLoop.kt
@@ -83,11 +83,25 @@ fun runRoom(room: Room, creepsByRoleAndRoom: Map<CreepRole, Map<Room, List<Creep
 
 fun claimNewRooms(creepsByRoomAndRole: Map<CreepRole, Map<Room, List<Creep>>>) {
     val nextRoomFlag = Game.flags["NextRoom"] ?: return console.log("No NextRoom flag, skipping claim room routine")
-    val claimer =
-        creepsByRoomAndRole[CreepRole.CLAIMER]?.flatMap { it.value }?.firstOrNull() ?: spawnClaimer(nextRoomFlag)
-        ?: return console.log("No claimer creep could be located or created")
 
-    Role.build(CreepRole.CLAIMER, claimer).run()
+    if (nextRoomFlag.memory.spawnerId == null) {
+        val claimer =
+            creepsByRoomAndRole[CreepRole.CLAIMER]?.flatMap { it.value }?.firstOrNull()
+                ?: spawnCrossRoomCreep(
+                    CreepRole.CLAIMER, nextRoomFlag
+                )
+                ?: return console.log("No claimer creep could be located or created")
+
+        Role.build(CreepRole.CLAIMER, claimer).run()
+    }
+    else {
+        val builder = creepsByRoomAndRole[CreepRole.REMOTE_CONSTRUCTION]?.flatMap { it.value }?.firstOrNull()
+            ?: spawnCrossRoomCreep(
+                CreepRole.REMOTE_CONSTRUCTION, nextRoomFlag
+            ) ?: return console.log("No RCV could be located or created")
+
+        Role.build(CreepRole.REMOTE_CONSTRUCTION, builder).run()
+    }
 }
 
 

--- a/src/main/kotlin/screepsai/Spawning.kt
+++ b/src/main/kotlin/screepsai/Spawning.kt
@@ -42,6 +42,9 @@ val BUILDER_BODIES = arrayOf(
     Body(arrayOf(WORK, CARRY, CARRY, CARRY, MOVE)),
     Body(arrayOf(MOVE, MOVE, WORK, WORK, CARRY, CARRY, CARRY, CARRY, CARRY))
 )
+val CLAIMER_BODIES = arrayOf(
+    Body(arrayOf(MOVE, CLAIM)),
+)
 
 fun getBody(role: CreepRole, energyAvailable: Int): Body {
     val bodies = when (role) {
@@ -51,6 +54,7 @@ fun getBody(role: CreepRole, energyAvailable: Int): Body {
         CreepRole.TRANSPORTER -> TRANSPORTER_BODIES
         CreepRole.BUILDER     -> BUILDER_BODIES
         CreepRole.MAINTAINER  -> BUILDER_BODIES
+        CreepRole.CLAIMER     -> CLAIMER_BODIES
     }
 
     return bodies.last { it.cost <= energyAvailable }
@@ -99,6 +103,21 @@ fun spawnNewCreep(
     }
     console.log("Unable to spawn new ${role} creep in ${room}")
     return null
+}
+
+
+fun spawnClaimer(targetFlag: Flag): Creep? {
+    val body = CLAIMER_BODIES[0]
+    val spawner = Game.spawns.values.filter { it.room.energyAvailable > body.cost }.minByOrNull {
+        it.pos.getRangeTo(targetFlag)
+    }
+
+    if (spawner == null) {
+        console.log("Cannot claim a room if no spawners are available!")
+        return null
+    }
+
+    return spawnCreep(spawner, CreepRole.CLAIMER, CLAIMER_BODIES[0])
 }
 
 fun houseKeeping(creeps: Record<String, Creep>) {

--- a/src/main/kotlin/screepsai/Spawning.kt
+++ b/src/main/kotlin/screepsai/Spawning.kt
@@ -42,19 +42,38 @@ val BUILDER_BODIES = arrayOf(
     Body(arrayOf(WORK, CARRY, CARRY, CARRY, MOVE)),
     Body(arrayOf(MOVE, MOVE, WORK, WORK, CARRY, CARRY, CARRY, CARRY, CARRY))
 )
+
 val CLAIMER_BODIES = arrayOf(
     Body(arrayOf(MOVE, CLAIM)),
 )
 
+val REMOTE_CONSTRUCTION_BODIES = arrayOf(
+    Body(
+        arrayOf(
+            MOVE, MOVE, MOVE, MOVE, MOVE,
+            MOVE, MOVE, MOVE, MOVE, MOVE,
+            MOVE, MOVE, MOVE, MOVE, MOVE,
+            MOVE, MOVE, MOVE, MOVE, MOVE,
+            WORK, WORK, WORK, WORK, WORK,
+            WORK, WORK, WORK, WORK, WORK,
+            CARRY, CARRY, CARRY, CARRY, CARRY,
+            CARRY, CARRY, CARRY, CARRY, CARRY,
+            CARRY, CARRY, CARRY, CARRY, CARRY,
+            CARRY, CARRY, CARRY, CARRY, CARRY
+        )
+    ),
+)
+
 fun getBody(role: CreepRole, energyAvailable: Int): Body {
     val bodies = when (role) {
-        CreepRole.UNASSIGNED  -> return BASE_BODY
-        CreepRole.HARVESTER   -> HARVESTER_BODIES
-        CreepRole.UPGRADER    -> UPGRADER_BODIES
-        CreepRole.TRANSPORTER -> TRANSPORTER_BODIES
-        CreepRole.BUILDER     -> BUILDER_BODIES
-        CreepRole.MAINTAINER  -> BUILDER_BODIES
-        CreepRole.CLAIMER     -> CLAIMER_BODIES
+        CreepRole.UNASSIGNED          -> return BASE_BODY
+        CreepRole.HARVESTER           -> HARVESTER_BODIES
+        CreepRole.UPGRADER            -> UPGRADER_BODIES
+        CreepRole.TRANSPORTER         -> TRANSPORTER_BODIES
+        CreepRole.BUILDER             -> BUILDER_BODIES
+        CreepRole.MAINTAINER          -> BUILDER_BODIES
+        CreepRole.CLAIMER             -> CLAIMER_BODIES
+        CreepRole.REMOTE_CONSTRUCTION -> REMOTE_CONSTRUCTION_BODIES
     }
 
     return bodies.last { it.cost <= energyAvailable }
@@ -67,7 +86,7 @@ fun spawnCreep(spawn: StructureSpawn, role: CreepRole, body: Body): Creep? {
         OK                    -> console.log("spawning $newName with body ${body.parts}")
         ERR_BUSY              -> console.log("Spawner ${spawn} in ${spawn.room} is busy")
         ERR_NOT_ENOUGH_ENERGY -> console.log("Not enough energy to spawn a new ${role.name}")
-        else                  -> console.log("unhandled error code $code")
+        else                  -> console.log("Unhandled error code $code")
     }
 
     if (code != OK) {
@@ -106,18 +125,23 @@ fun spawnNewCreep(
 }
 
 
-fun spawnClaimer(targetFlag: Flag): Creep? {
-    val body = CLAIMER_BODIES[0]
+fun spawnCrossRoomCreep(role: CreepRole, targetFlag: Flag): Creep? {
+    val body = when (role) {
+        CreepRole.CLAIMER             -> CLAIMER_BODIES[0]
+        CreepRole.REMOTE_CONSTRUCTION -> REMOTE_CONSTRUCTION_BODIES[0]
+        else                          -> throw IllegalArgumentException("${role} not supported yet")
+    }
+
     val spawner = Game.spawns.values.filter { it.room.energyAvailable > body.cost }.minByOrNull {
         it.pos.getRangeTo(targetFlag)
     }
 
     if (spawner == null) {
-        console.log("Cannot claim a room if no spawners are available!")
+        console.log("No spawners available to create a new ${role}!")
         return null
     }
 
-    return spawnCreep(spawner, CreepRole.CLAIMER, CLAIMER_BODIES[0])
+    return spawnCreep(spawner, role, body)
 }
 
 fun houseKeeping(creeps: Record<String, Creep>) {

--- a/src/main/kotlin/screepsai/Spawning.kt
+++ b/src/main/kotlin/screepsai/Spawning.kt
@@ -56,7 +56,7 @@ fun getBody(role: CreepRole, energyAvailable: Int): Body {
     return bodies.last { it.cost <= energyAvailable }
 }
 
-fun spawnCreep(spawn: StructureSpawn, role: CreepRole, body: Body): ScreepsReturnCode {
+fun spawnCreep(spawn: StructureSpawn, role: CreepRole, body: Body): Creep? {
     val newName = "creep_${role.name}_${Game.time}"
     val code = spawn.spawnCreep(body.parts, newName)
     when (code) {
@@ -67,37 +67,38 @@ fun spawnCreep(spawn: StructureSpawn, role: CreepRole, body: Body): ScreepsRetur
     }
 
     if (code != OK) {
-        return code
+        return null
     }
 
     val creep = Game.creeps[newName]!!
     creep.setRole(role)
 
-    return code
+    return creep
 }
 
-fun spawnCreeps(
+fun spawnNewCreep(
     role: CreepRole,
     room: Room
-) {
+): Creep? {
 
     val body = try {
         getBody(role, room.energyAvailable)
     }
     catch (error: NoSuchElementException) {
-        console.log("Couldn't determine body for ${role} with ${room.energyAvailable} energy")
-        return
+        console.log("Couldn't determine body for ${role} in ${room} with ${room.energyAvailable} energy")
+        return null
     }
 
     val spawns = room.find(FIND_MY_SPAWNS)
 
     for (spawn in spawns) {
-        val code = spawnCreep(spawn, role, body)
-        if (code == OK) {
-            return
+        val creep = spawnCreep(spawn, role, body)
+        if (creep != null) {
+            return creep
         }
     }
     console.log("Unable to spawn new ${role} creep in ${room}")
+    return null
 }
 
 fun houseKeeping(creeps: Record<String, Creep>) {

--- a/src/main/kotlin/screepsai/Turret.kt
+++ b/src/main/kotlin/screepsai/Turret.kt
@@ -26,6 +26,10 @@ fun repairWalls(tower: StructureTower) {
 
     if (wall.hits.toFloat() / maxWallHp.toFloat() > 0.9) {
         console.log("${tower} not repairing since all walls are roughly same hp")
+    }
+
+    if (wall.structureType == STRUCTURE_RAMPART && wall.hits > 500000) {
+        console.log("${tower} not repairing since ramparts are healthy")
         return
     }
 

--- a/src/main/kotlin/screepsai/roles/Claimer.kt
+++ b/src/main/kotlin/screepsai/roles/Claimer.kt
@@ -1,0 +1,105 @@
+package screepsai.roles
+
+import screeps.api.*
+import screeps.api.structures.StructureController
+import screeps.utils.unsafe.jsObject
+
+class Claimer(creep: Creep) : Role(creep) {
+
+    private val targetFlag: Flag? = Game.flags["NextRoom"]
+    private val targetController: StructureController? = targetFlag?.room?.controller
+
+    override fun run() {
+        claimRoom()
+    }
+
+    private fun getRoomCostMatrix(roomName: String): CostMatrix {
+        val costMatrix = PathFinder.CostMatrix()
+        val room = Game.rooms[roomName]
+        if (room == null) {
+            debug("${roomName} not known, returning default cost matrix")
+            return costMatrix
+        }
+
+        for (structure in room.find(FIND_STRUCTURES)) {
+            if (structure.structureType == STRUCTURE_ROAD) {
+                costMatrix.set(structure.pos.x, structure.pos.y, 1)
+            }
+            else if (structure.structureType == STRUCTURE_RAMPART && structure.my) {
+                debug("${structure} is a rampart")
+            }
+            else if (structure.structureType != STRUCTURE_CONTAINER) {
+                // Can't walk through non-walkable buildings
+                debug("${structure} is not walkable")
+                costMatrix.set(structure.pos.x, structure.pos.y, 750)
+            }
+        }
+
+        return costMatrix
+    }
+
+    private fun getPathToTarget(target: RoomPosition): Array<RoomPosition> {
+
+        val searchResult = PathFinder.search(creep.pos, target, options = jsObject {
+            plainCost = 1
+            swampCost = 5
+            roomCallback = this@Claimer::getRoomCostMatrix
+        })
+
+        if (searchResult.incomplete) {
+            error("Could not find path to ${target}")
+        }
+
+        info("Target controller is ${searchResult.path.size} tiles away")
+        for (position in searchResult.path.withIndex()) {
+            debug("Position ${position.index}: ${position.value}")
+            if (position.value.roomName != creep.room.name) {
+                debug("End of positions in current room, there are  ${searchResult.path.size - position.index} positions left in path")
+                break
+            }
+        }
+
+        return searchResult.path
+    }
+
+    private fun moveToFlag() {
+        if (targetFlag == null) {
+            error("No target room flag located!")
+            return
+        }
+
+        val path = getPathToTarget(targetFlag.pos)
+        creep.move(creep.pos.getDirectionTo(path[0]))
+    }
+
+    private fun claimRoom() {
+        if (targetController == null || targetController.room != creep.room) {
+            warning("Not in room with controller, navigating to ${targetFlag} instead")
+            moveToFlag()
+            return
+        }
+
+        if (targetController.my) {
+            info("${targetController} already claimed!")
+            setupRoom(targetController.room)
+            return
+        }
+
+        when (val code = creep.claimController(targetController)) {
+            OK               -> info("${targetController.room} claimed!")
+            ERR_NOT_IN_RANGE -> creep.moveTo(targetController)
+            else             -> error("Claiming ${targetController.room} failed: ${code}")
+        }
+    }
+
+    private fun setupRoom(room: Room) {
+        val spawnPos = targetFlag?.pos ?: return error("Could not find flag to create initial spawn")
+
+        val code = room.createConstructionSite(spawnPos, STRUCTURE_SPAWN)
+
+        if (code == OK) {
+            info("${room} successfully initialized, construction may begin!")
+            targetFlag.remove()
+        }
+    }
+}

--- a/src/main/kotlin/screepsai/roles/Claimer.kt
+++ b/src/main/kotlin/screepsai/roles/Claimer.kt
@@ -2,7 +2,10 @@ package screepsai.roles
 
 import screeps.api.*
 import screeps.api.structures.StructureController
+import screeps.utils.memory.memory
 import screepsai.utils.*
+
+var FlagMemory.spawnerId: String? by memory()
 
 class Claimer(creep: Creep) : Role(creep) {
 
@@ -48,9 +51,11 @@ class Claimer(creep: Creep) : Role(creep) {
 
         val code = room.createConstructionSite(spawnPos, STRUCTURE_SPAWN)
 
+        val spawner = room.find(FIND_CONSTRUCTION_SITES).first()
+        targetFlag.memory.spawnerId = spawner.id
+
         if (code == OK) {
             info("${room} successfully initialized, construction may begin!")
-            targetFlag.remove()
         }
     }
 }

--- a/src/main/kotlin/screepsai/roles/Claimer.kt
+++ b/src/main/kotlin/screepsai/roles/Claimer.kt
@@ -2,7 +2,7 @@ package screepsai.roles
 
 import screeps.api.*
 import screeps.api.structures.StructureController
-import screeps.utils.unsafe.jsObject
+import screepsai.utils.*
 
 class Claimer(creep: Creep) : Role(creep) {
 
@@ -13,62 +13,13 @@ class Claimer(creep: Creep) : Role(creep) {
         claimRoom()
     }
 
-    private fun getRoomCostMatrix(roomName: String): CostMatrix {
-        val costMatrix = PathFinder.CostMatrix()
-        val room = Game.rooms[roomName]
-        if (room == null) {
-            debug("${roomName} not known, returning default cost matrix")
-            return costMatrix
-        }
-
-        for (structure in room.find(FIND_STRUCTURES)) {
-            if (structure.structureType == STRUCTURE_ROAD) {
-                costMatrix.set(structure.pos.x, structure.pos.y, 1)
-            }
-            else if (structure.structureType == STRUCTURE_RAMPART && structure.my) {
-                debug("${structure} is a rampart")
-            }
-            else if (structure.structureType != STRUCTURE_CONTAINER) {
-                // Can't walk through non-walkable buildings
-                debug("${structure} is not walkable")
-                costMatrix.set(structure.pos.x, structure.pos.y, 750)
-            }
-        }
-
-        return costMatrix
-    }
-
-    private fun getPathToTarget(target: RoomPosition): Array<RoomPosition> {
-
-        val searchResult = PathFinder.search(creep.pos, target, options = jsObject {
-            plainCost = 1
-            swampCost = 5
-            roomCallback = this@Claimer::getRoomCostMatrix
-        })
-
-        if (searchResult.incomplete) {
-            error("Could not find path to ${target}")
-        }
-
-        info("Target controller is ${searchResult.path.size} tiles away")
-        for (position in searchResult.path.withIndex()) {
-            debug("Position ${position.index}: ${position.value}")
-            if (position.value.roomName != creep.room.name) {
-                debug("End of positions in current room, there are  ${searchResult.path.size - position.index} positions left in path")
-                break
-            }
-        }
-
-        return searchResult.path
-    }
-
     private fun moveToFlag() {
         if (targetFlag == null) {
             error("No target room flag located!")
             return
         }
 
-        val path = getPathToTarget(targetFlag.pos)
+        val path = getPathToTarget(creep.pos, targetFlag.pos)
         creep.move(creep.pos.getDirectionTo(path[0]))
     }
 

--- a/src/main/kotlin/screepsai/roles/RemoteConstructionVehicle.kt
+++ b/src/main/kotlin/screepsai/roles/RemoteConstructionVehicle.kt
@@ -1,0 +1,118 @@
+package screepsai.roles
+
+import screeps.api.*
+import screepsai.utils.getPathToTarget
+
+class RemoteConstructionVehicle(creep: Creep) : Role(creep) {
+    private val targetFlag: Flag? = Game.flags["NextRoom"]
+
+    override fun run() {
+        if (targetFlag == null) {
+            error("No target to work with!")
+            return
+        }
+
+        // Move to target room if not in room
+        if (creep.room != targetFlag.room) {
+            creep.move(creep.pos.getDirectionTo(getPathToTarget(creep.pos, targetFlag.pos)[0]))
+            return
+        }
+
+        if (state == CreepState.GET_ENERGY) {
+            getEnergy()
+        }
+        else if (state == CreepState.DO_WORK) {
+            buildBuildings()
+        }
+    }
+
+    private fun gatherEnergy() {
+        val energySource =
+            creep.room.find(FIND_SOURCES).firstOrNull { it.energy > 0 } ?: return error("No energy available!")
+
+        val code = creep.harvest(energySource)
+
+        if (code == ERR_NOT_IN_RANGE) {
+            creep.moveTo(energySource)
+        }
+        else if (code != OK) {
+            error("Gather failed with code ${code}")
+        }
+
+        if ((creep.store.getFreeCapacity(RESOURCE_ENERGY) ?: 0) <= 0) {
+            state = CreepState.DO_WORK
+        }
+    }
+
+    private fun getEnergy() {
+        val storage = creep.room.storage
+
+        if (storage == null || (storage.store.getUsedCapacity(RESOURCE_ENERGY) ?: 0) <= 0) {
+            debug("No storage in room, going to gather instead")
+            gatherEnergy()
+            return
+        }
+
+        val code = creep.withdraw(storage, RESOURCE_ENERGY)
+        if (code == ERR_NOT_IN_RANGE) {
+            creep.moveTo(storage)
+        }
+        else if (code != OK) {
+            error("Couldn't withdraw from storage due to error: $code")
+        }
+    }
+
+    private fun findConstructionSite(): ConstructionSite? {
+        return targetFlag?.room?.find(FIND_CONSTRUCTION_SITES)?.firstOrNull()
+    }
+
+    private fun depositEnergy() {
+        val spawner = creep.room.find(FIND_MY_SPAWNS).firstOrNull() ?: return error("No spawner to deposit energy into")
+
+        val code = creep.transfer(spawner, RESOURCE_ENERGY)
+
+        if (code == ERR_NOT_IN_RANGE) {
+            creep.moveTo(spawner)
+        }
+        else if (code == ERR_NOT_ENOUGH_ENERGY) {
+            info("Out of energy", say = true)
+            state = CreepState.GET_ENERGY
+            return
+        }
+        else if (code != OK) {
+            error("Transfer failed with code ${code}", say = true)
+        }
+
+        if (creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0) {
+            state = CreepState.GET_ENERGY
+        }
+    }
+
+    private fun buildBuildings() {
+        val constructionSite = findConstructionSite()
+
+        if (constructionSite == null) {
+            warning("No available construction site!")
+            depositEnergy()
+            return
+        }
+
+        val status = creep.build(constructionSite)
+
+        if (status == ERR_NOT_IN_RANGE) {
+            creep.move(creep.pos.getDirectionTo(getPathToTarget(creep.pos, constructionSite.pos)[0]))
+        }
+        else if (status == ERR_NOT_ENOUGH_ENERGY) {
+            info("Out of energy", say = true)
+            state = CreepState.GET_ENERGY
+            return
+        }
+        else if (status != OK) {
+            error("Build failed with code $status", say = true)
+        }
+
+        if (creep.store.getCapacity(RESOURCE_ENERGY) <= 0) {
+            state = CreepState.GET_ENERGY
+        }
+    }
+}

--- a/src/main/kotlin/screepsai/roles/RemoteConstructionVehicle.kt
+++ b/src/main/kotlin/screepsai/roles/RemoteConstructionVehicle.kt
@@ -1,7 +1,10 @@
 package screepsai.roles
 
 import screeps.api.*
+import screeps.utils.memory.memory
 import screepsai.utils.getPathToTarget
+
+var FlagMemory.complete: Boolean by memory { false }
 
 class RemoteConstructionVehicle(creep: Creep) : Role(creep) {
     private val targetFlag: Flag? = Game.flags["NextRoom"]
@@ -10,6 +13,11 @@ class RemoteConstructionVehicle(creep: Creep) : Role(creep) {
         if (targetFlag == null) {
             error("No target to work with!")
             return
+        }
+
+        if (targetFlag.room?.find(FIND_MY_SPAWNS)?.firstOrNull() != null) {
+            info("Spawn construction completed!")
+            targetFlag.memory.complete = true
         }
 
         // Move to target room if not in room
@@ -100,7 +108,12 @@ class RemoteConstructionVehicle(creep: Creep) : Role(creep) {
         val status = creep.build(constructionSite)
 
         if (status == ERR_NOT_IN_RANGE) {
-            creep.move(creep.pos.getDirectionTo(getPathToTarget(creep.pos, constructionSite.pos)[0]))
+            if (creep.room != constructionSite.room) {
+                creep.move(creep.pos.getDirectionTo(getPathToTarget(creep.pos, constructionSite.pos)[0]))
+            }
+            else {
+                creep.moveTo(constructionSite)
+            }
         }
         else if (status == ERR_NOT_ENOUGH_ENERGY) {
             info("Out of energy", say = true)

--- a/src/main/kotlin/screepsai/roles/Role.kt
+++ b/src/main/kotlin/screepsai/roles/Role.kt
@@ -14,7 +14,8 @@ enum class CreepRole {
     UPGRADER,
     BUILDER,
     MAINTAINER,
-    CLAIMER
+    CLAIMER,
+    REMOTE_CONSTRUCTION
 }
 
 enum class CreepState {
@@ -41,13 +42,14 @@ abstract class Role(val creep: Creep) {
          */
         fun build(creepRole: CreepRole, creep: Creep): Role {
             return when (creepRole) {
-                CreepRole.UNASSIGNED  -> throw IllegalArgumentException("Cannot process a creep without a role")
-                CreepRole.HARVESTER   -> Harvester(creep)
-                CreepRole.UPGRADER    -> Upgrader(creep)
-                CreepRole.TRANSPORTER -> Transporter(creep)
-                CreepRole.BUILDER     -> Builder(creep)
-                CreepRole.MAINTAINER  -> Maintainer(creep)
-                CreepRole.CLAIMER     -> Claimer(creep)
+                CreepRole.UNASSIGNED          -> throw IllegalArgumentException("Cannot process a creep without a role")
+                CreepRole.HARVESTER           -> Harvester(creep)
+                CreepRole.UPGRADER            -> Upgrader(creep)
+                CreepRole.TRANSPORTER         -> Transporter(creep)
+                CreepRole.BUILDER             -> Builder(creep)
+                CreepRole.MAINTAINER          -> Maintainer(creep)
+                CreepRole.CLAIMER             -> Claimer(creep)
+                CreepRole.REMOTE_CONSTRUCTION -> RemoteConstructionVehicle(creep)
             }
         }
     }

--- a/src/main/kotlin/screepsai/roles/Role.kt
+++ b/src/main/kotlin/screepsai/roles/Role.kt
@@ -13,7 +13,8 @@ enum class CreepRole {
     TRANSPORTER,
     UPGRADER,
     BUILDER,
-    MAINTAINER
+    MAINTAINER,
+    CLAIMER
 }
 
 enum class CreepState {
@@ -46,6 +47,7 @@ abstract class Role(val creep: Creep) {
                 CreepRole.TRANSPORTER -> Transporter(creep)
                 CreepRole.BUILDER     -> Builder(creep)
                 CreepRole.MAINTAINER  -> Maintainer(creep)
+                CreepRole.CLAIMER     -> Claimer(creep)
             }
         }
     }

--- a/src/main/kotlin/screepsai/utils/Pathfinding.kt
+++ b/src/main/kotlin/screepsai/utils/Pathfinding.kt
@@ -1,0 +1,53 @@
+package screepsai.utils
+
+import screeps.api.*
+import screeps.utils.unsafe.jsObject
+
+fun getRoomCostMatrix(roomName: String): CostMatrix {
+    val costMatrix = PathFinder.CostMatrix()
+    val room = Game.rooms[roomName]
+    if (room == null) {
+        console.log("${roomName} not known, returning default cost matrix")
+        return costMatrix
+    }
+
+    for (structure in room.find(FIND_STRUCTURES)) {
+        if (structure.structureType == STRUCTURE_ROAD) {
+            costMatrix.set(structure.pos.x, structure.pos.y, 1)
+        }
+        else if (structure.structureType == STRUCTURE_RAMPART && structure.my) {
+            console.log("${structure} is a rampart")
+        }
+        else if (structure.structureType != STRUCTURE_CONTAINER) {
+            // Can't walk through non-walkable buildings
+            console.log("${structure} is not walkable")
+            costMatrix.set(structure.pos.x, structure.pos.y, 750)
+        }
+    }
+
+    return costMatrix
+}
+
+fun getPathToTarget(start: RoomPosition, target: RoomPosition): Array<RoomPosition> {
+
+    val searchResult = PathFinder.search(start, target, options = jsObject {
+        plainCost = 1
+        swampCost = 5
+        roomCallback = ::getRoomCostMatrix
+    })
+
+    if (searchResult.incomplete) {
+        console.log("Could not find complete path from ${start} to ${target}")
+    }
+
+    console.log("Target is ${searchResult.path.size} tiles away")
+    for (position in searchResult.path.withIndex()) {
+        console.log("Position ${position.index}: ${position.value}")
+        if (position.index > 10) {
+            console.log("Truncating position logs, there are  ${searchResult.path.size - position.index} positions left in path")
+            break
+        }
+    }
+
+    return searchResult.path
+}


### PR DESCRIPTION
This PR adds two new roles used for establishing a spawner in a new room.

The `Claimer` role is responsible for using the `CLAIM` body part to claim neutral room controllers.

The `RemoteConstructionVehicle` is a massive 50 body creep designed to travel quickly to the new room, gather energy, and build the spawner without having to rely on roads for reasonable travel times.

Both the `Claimer` and `RemoteConstructionVehicle` roles will only be built as needed. Once the spawner is build in the new room, the script won't create any new creeps for that room outside of that room. The `RemoteConstructionVehicle` creeps in the room when the spawner is completed will remain in the room and assist with building the rooms initial structures and filling the new spawner with energy.

Claiming a new room is as simple as setting up a new flag with the name `NextRoom` on the position that you want the new room's inital spawner to be located.

# Potential Issues

The `RemoteConstructionVehicle` currently only has one body option, and that is a `50` part body. This limits the ability to expand to new rooms until the first room is well established. This just happens to be the case for my current play since it took time to write the logic and I wasn't able to work on the code constantly. By the time I got around to implementing this, my room was already at RCL 7 and had more than enough energy flowing to pump out these 50 part creeps.

There's no reason the body has to be 50 parts, just a smaller creep would take longer. The logic currently is hard coded for a single body option, but again, there is no strong reason for it being that way.

Additionally, there currently is no logic for escorting these new creeps. They will blindly travel the shortest path, so going through any hostile rooms to claim a new room is not an option here.

Also, the claimer is not set up to reserve or attack other room controllers, even though the body would be capable of doing so.

closes #9 
closes #40 