### PR TITLE
Tuning

### DIFF
--- a/src/main/kotlin/screepsai/GameLoop.kt
+++ b/src/main/kotlin/screepsai/GameLoop.kt
@@ -20,8 +20,8 @@ fun getCreepsByRole(): Map<CreepRole, Map<Room, List<Creep>>> {
 val roleMemberCount = mapOf(
     CreepRole.HARVESTER to 2,
     CreepRole.TRANSPORTER to 2,
-    CreepRole.MAINTAINER to 2,
-    CreepRole.UPGRADER to 8,
+    CreepRole.MAINTAINER to 1,
+    CreepRole.UPGRADER to 4,
     CreepRole.BUILDER to 1
 )
 
@@ -49,6 +49,17 @@ fun runRoom(room: Room, creepsByRoleAndRoom: Map<CreepRole, Map<Room, List<Creep
     else {
         console.log("All roles filled in ${room}")
     }
+    var prioritySpawnActive = false
+    if ((creepsByRole[CreepRole.HARVESTER]?.size ?: 0) < (room.find(FIND_SOURCES).size)) {
+        console.log("${room} spawning priority harvester")
+        spawnNewCreep(CreepRole.HARVESTER, room)
+        prioritySpawnActive = true
+    }
+    else if ((creepsByRole[CreepRole.TRANSPORTER]?.size ?: 0) < roleMemberCount[CreepRole.TRANSPORTER]) {
+        console.log("${room} spawning priority transporter")
+        spawnNewCreep(CreepRole.TRANSPORTER, room)
+        prioritySpawnActive = true
+    }
 
     for (record in creepsByRole) {
         val creepRole = record.key
@@ -57,7 +68,7 @@ fun runRoom(room: Room, creepsByRoleAndRoom: Map<CreepRole, Map<Room, List<Creep
         val maxCreepsInRole = roleMemberCount[creepRole] ?: 0
         console.log("${room} ${creepRole}: ${creepCount}/${maxCreepsInRole}")
         // Spawn more creeps if we are not at the desired volume
-        if (creepCount < maxCreepsInRole) {
+        if (creepCount < maxCreepsInRole && !prioritySpawnActive) {
             if (creepCount <= minCreepsInUnfilledRole) {
                 spawnNewCreep(creepRole, room)
             }

--- a/src/main/kotlin/screepsai/roles/Maintainer.kt
+++ b/src/main/kotlin/screepsai/roles/Maintainer.kt
@@ -58,7 +58,7 @@ class Maintainer(creep: Creep) : Role(creep) {
                     val ratio = it.hits.toFloat() / it.hitsMax.toFloat()
                     // Chunk float into multiple levels so the creep is less sensitive to repair progress
                     // this makes the creeps focus on repairing a single target until it moves into the next "bucket"
-                    (ratio * 1000).toInt()
+                    (ratio * (it.hitsMax / creep.store.getCapacity(RESOURCE_ENERGY)!!)).toInt()
                 }
             if (wall != null) {
                 info("Buildings well maintained, repairing ${wall} instead")

--- a/src/main/kotlin/screepsai/roles/Transporter.kt
+++ b/src/main/kotlin/screepsai/roles/Transporter.kt
@@ -27,7 +27,15 @@ class Transporter(creep: Creep) : Role(creep) {
         val status = pickupEnergy()
 
         if (status == ERR_NOT_FOUND) {
-            val storage = creep.room.storage ?: return
+            val storage = creep.room.storage
+            if (storage == null || storage.store.getUsedCapacity(RESOURCE_ENERGY) <= 0) {
+                warning("No energy could be found in room", say = true)
+                // Try to transport whatever energy we do have while waiting on more to be generated
+                if (creep.store.getUsedCapacity(RESOURCE_ENERGY) > 50) {
+                    state = CreepState.DO_WORK
+                }
+                return
+            }
             warning("No energy to pick up, gathering from storage")
             val code = creep.withdraw(storage, RESOURCE_ENERGY)
             if (code == ERR_NOT_IN_RANGE) {

--- a/src/main/kotlin/screepsai/roles/Transporter.kt
+++ b/src/main/kotlin/screepsai/roles/Transporter.kt
@@ -61,10 +61,10 @@ class Transporter(creep: Creep) : Role(creep) {
             when (it.unsafeCast<Structure>().structureType) {
                 // TODO: Determine priority level more intelligently
                 STRUCTURE_SPAWN     -> 1
-                STRUCTURE_EXTENSION -> 2
-                STRUCTURE_TOWER     -> 3
-                STRUCTURE_STORAGE   -> 4
-                else                -> 5
+                STRUCTURE_EXTENSION -> 1
+                STRUCTURE_TOWER     -> 2
+                STRUCTURE_STORAGE   -> 3
+                else                -> 4
             }
         }
 

--- a/src/main/kotlin/screepsai/roles/Upgrader.kt
+++ b/src/main/kotlin/screepsai/roles/Upgrader.kt
@@ -22,7 +22,11 @@ class Upgrader(creep: Creep) : Role(creep) {
         val storage = creep.room.storage
 
         if (storage == null || (storage.store.getUsedCapacity(RESOURCE_ENERGY) ?: 0) <= 0) {
-            pickupEnergy()
+            val code = pickupEnergy()
+            // If no energy could be found, try and use whatever energy we do have
+            if (code == ERR_NOT_FOUND && creep.store.getUsedCapacity(RESOURCE_ENERGY) > 0) {
+                state = CreepState.DO_WORK
+            }
             return
         }
 


### PR DESCRIPTION
This PR adds a couple of QOL and performance tuning enhancements.

Since we now have multiple rooms in different states, the logic needs to be able to adapt to different circumstances better.

The main change for this is the addition of "priority roles" that the AI will attempt to spawn before filling out the other roles. For now, those are the `Harvester` and `Transporter` roles so that a room will harvest energy and move it into the spawners/extensions so that creeps can be spawned at a reasonable rate.

Another change is to allow upgraders and transporters to bail out of the gather energy mode early when no energy can be found, yet they have some in their store. This gets the upgraders out of the way so that other roles can get less contested access to the energy being actively mined. This also means the transporters may move energy that is needed to respawn a harvester into a spawner/extension instead of just complaining that there is no harvester gathering energy.