### PR TITLE
Tuning

### DIFF
--- a/src/main/kotlin/screepsai/GameLoop.kt
+++ b/src/main/kotlin/screepsai/GameLoop.kt
@@ -21,8 +21,8 @@ val roleMemberCount = mapOf(
     CreepRole.HARVESTER to 2,
     CreepRole.TRANSPORTER to 2,
     CreepRole.MAINTAINER to 1,
-    CreepRole.UPGRADER to 4,
-    CreepRole.BUILDER to 1
+    CreepRole.UPGRADER to 8,
+    CreepRole.BUILDER to 2
 )
 
 fun runRoom(room: Room, creepsByRoleAndRoom: Map<CreepRole, Map<Room, List<Creep>>>) {
@@ -65,7 +65,12 @@ fun runRoom(room: Room, creepsByRoleAndRoom: Map<CreepRole, Map<Room, List<Creep
         val creepRole = record.key
         val creeps = record.value
         val creepCount = creeps.size
-        val maxCreepsInRole = roleMemberCount[creepRole] ?: 0
+        var maxCreepsInRole = roleMemberCount[creepRole] ?: 0
+        // If room is still missing initial extensions, limit max creeps per role
+        if (room.energyCapacityAvailable < 550 && maxCreepsInRole > 2) {
+            maxCreepsInRole = minOf(maxCreepsInRole, 2)
+            console.log("${room} still getting online, spawning max of ${maxCreepsInRole} ${creepRole.name}s")
+        }
         console.log("${room} ${creepRole}: ${creepCount}/${maxCreepsInRole}")
         // Spawn more creeps if we are not at the desired volume
         if (creepCount < maxCreepsInRole && !prioritySpawnActive) {

--- a/src/main/kotlin/screepsai/roles/RemoteConstructionVehicle.kt
+++ b/src/main/kotlin/screepsai/roles/RemoteConstructionVehicle.kt
@@ -60,7 +60,12 @@ class RemoteConstructionVehicle(creep: Creep) : Role(creep) {
         val code = creep.harvest(energySource)
 
         if (code == ERR_NOT_IN_RANGE) {
-            creep.moveTo(energySource)
+            if (creep.store.getUsedCapacity(RESOURCE_ENERGY) > 50) {
+                state = CreepState.DO_WORK
+            }
+            else {
+                creep.moveTo(energySource)
+            }
         }
         else if (code != OK) {
             error("Gather failed with code ${code}")
@@ -105,7 +110,7 @@ class RemoteConstructionVehicle(creep: Creep) : Role(creep) {
     }
 
     private fun findConstructionSite(): ConstructionSite? {
-        return if (targetFlag != null) {
+        return if (targetFlag != null && creep.room != targetFlag.room) {
             targetFlag.room?.find(FIND_CONSTRUCTION_SITES)?.firstOrNull()
         }
         else {
@@ -126,6 +131,11 @@ class RemoteConstructionVehicle(creep: Creep) : Role(creep) {
             info("Out of energy", say = true)
             state = CreepState.GET_ENERGY
             return
+        }
+        else if (code == ERR_FULL) {
+            info("Spawner full of energy, dropping energy for other creeps to use")
+            creep.drop(RESOURCE_ENERGY)
+            state = CreepState.GET_ENERGY
         }
         else if (code != OK) {
             error("Transfer failed with code ${code}", say = true)

--- a/src/main/kotlin/screepsai/roles/Role.kt
+++ b/src/main/kotlin/screepsai/roles/Role.kt
@@ -86,7 +86,7 @@ abstract class Role(val creep: Creep) {
     protected fun pickupEnergy(): ScreepsReturnCode {
         // TODO: Handle priority
         val energySource = creep.room.find(FIND_DROPPED_RESOURCES).filter { it.resourceType == RESOURCE_ENERGY }
-            .minByOrNull { (abs(creep.pos.x - it.pos.x) + abs(creep.pos.y - it.pos.y)) / it.amount }
+            .minByOrNull { (abs(creep.pos.x - it.pos.x) + abs(creep.pos.y - it.pos.y)).toFloat() / it.amount.toFloat() }
 
         if (energySource == null || energySource.amount < 10) {
             warning("No energy available!", say = true)


### PR DESCRIPTION
Another small tuning PR to make things run a little more smoothly for new rooms.

This PR makes the RCV a little smarter by having it spend energy when a source runs out before the RCV is full. Instead of hauling a bunch of heavy energy across a room to the next source, the RCV will use the energy it did manage to gather before moving to the next source.

Another RCV enhancement is what it does once there are no more tasks left for it to accomplish in a room. I could have added a more complex state machine to it, and direct it to upgrade the controller once the spawn is full of energy, but I think that will be easier/better to implement once the task queue is done. The RCV has a large body and can do most tasks in a room effectively and so when we have a task queue, it can just pick them as they come in.

This PR also has a fix for the energy pickup logic that most of the creeps use when there is no room storage. Once I had the RCV dropping energy next to the spawn, I realized creeps weren't prioritizing it even though it was by far the closest and largest pile of energy dropped on the floor. Turns out the logic for selecting the "best" dropped energy pile was using integer division that rendered the logic effectively useless.

Another change here is logic to cap the maximum number of creeps a new room spawns in a role. With the upgrader role being set to a high cap in other rooms, they end up stealing all of the energy in new rooms and delaying the construction of the first 5 extension and roads significantly.